### PR TITLE
Add bot-core to Sir Robin

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,4 +1,9 @@
-from bot.log import log
+from botcore.utils.logging import get_logger
+from botcore.utils.monkey_patches import apply_monkey_patches
+
+from bot.log import setup_logging
+
+log = get_logger(__name__)
 
 try:
     from dotenv import load_dotenv
@@ -6,3 +11,9 @@ try:
     load_dotenv(override=True)
 except ModuleNotFoundError:
     pass
+
+
+setup_logging()
+
+# Apply all monkey patches from bot core.
+apply_monkey_patches()

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -1,7 +1,12 @@
+from botcore.utils.extensions import walk_extensions
+
+from bot import exts
 from bot.bot import bot
 from bot.constants import Client
 
-bot.load_extension("bot.exts.ping")
+for extension in walk_extensions(exts):
+    bot.load_extension(extension)
+
 
 if not Client.in_ci:
     bot.run(Client.token)

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,7 +1,9 @@
+from botcore.utils.logging import get_logger
 from disnake.ext import commands
 
 from bot import constants
-from bot.log import log
+
+log = get_logger(__name__)
 
 
 class SirRobin(commands.Bot):

--- a/bot/exts/ping.py
+++ b/bot/exts/ping.py
@@ -1,8 +1,10 @@
+from botcore.utils.logging import get_logger
 from disnake import Embed
 from disnake.ext import commands
 
 from bot.bot import SirRobin
-from bot.log import log
+
+log = get_logger(__name__)
 
 
 class Ping(commands.Cog):

--- a/bot/log.py
+++ b/bot/log.py
@@ -1,9 +1,23 @@
 import logging
+import sys
 
-log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
-ch = logging.StreamHandler()
-ch.setLevel(logging.DEBUG)
-format_string = logging.Formatter("%(asctime)s | %(name)s | %(levelname)s | %(message)s")
-ch.setFormatter(format_string)
-log.addHandler(ch)
+from botcore.utils.logging import get_logger
+
+
+def setup_logging() -> None:
+    """Configure logging for the bot."""
+    root_log = get_logger()
+    root_log.setLevel(logging.DEBUG)
+
+    ch = logging.StreamHandler(stream=sys.stdout)
+    ch.setLevel(logging.DEBUG)
+    format_string = logging.Formatter("%(asctime)s | %(name)s | %(levelname)s | %(message)s")
+    ch.setFormatter(format_string)
+    root_log.addHandler(ch)
+
+    get_logger("disnake").setLevel(logging.WARNING)
+
+    # Set back to the default of INFO even if asyncio's debug mode is enabled.
+    get_logger("asyncio").setLevel(logging.INFO)
+
+    root_log.info("Logging initialization complete.")

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,6 +52,20 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "bot-core"
+version = "2.0.0"
+description = "Bot-Core provides the core functionality and utilities for the bots of the Python Discord community."
+category = "main"
+optional = false
+python-versions = "3.9.*"
+
+[package.dependencies]
+disnake = ">=2,<3"
+
+[package.source]
+type = "url"
+url = "https://github.com/python-discord/bot-core/archive/5593a0c95e2b4fd9515c8875ea6e51c0ab88eb00.zip"
+[[package]]
 name = "cfgv"
 version = "3.3.1"
 description = "Validate configuration and produce human readable error messages."
@@ -441,8 +455,8 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9"
-content-hash = "754c901be5a63e8367ed71a83a969cfbecf06146e1e29c8c9a8143b83d22b7f7"
+python-versions = "3.9.*"
+content-hash = "40dcf4f2565a39256b8e6e7fbce5d14dec4d1732f8274c9591a060e5feb9b79a"
 
 [metadata.files]
 aiohttp = [
@@ -531,6 +545,7 @@ attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
+bot-core = []
 cfgv = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
     {file = "cfgv-3.3.1.tar.gz", hash = "sha256:f5a830efb9ce7a445376bb66ec94c638a9787422f96264c98edc6bdeed8ab736"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,9 @@ description = ""
 authors = ["Python Discord <info@pythondiscord.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "3.9.*"
 disnake = "^2.4.0"
+bot-core = {url = "https://github.com/python-discord/bot-core/archive/5593a0c95e2b4fd9515c8875ea6e51c0ab88eb00.zip"}
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"


### PR DESCRIPTION
Adds bot core to Sir Robin, utilizing the extension and logging utilities. Also adds fixes to logging, as it used to use one logger across modules.