### PR TITLE
add log message on startup and on guild available

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -15,10 +15,9 @@ class SirRobin(commands.Bot):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.name = "Sir-Robin"
         self._guild_available = asyncio.Event()
         create_task(self.check_channels(), event_loop=self.loop)
-        create_task(self.send_log(self.name, "Connected!"), event_loop=self.loop)
+        create_task(self.send_log(constants.Client.name, "Connected!"), event_loop=self.loop)
 
     def add_cog(self, cog: commands.Cog) -> None:
         """

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -2,6 +2,7 @@ import asyncio
 
 import disnake
 from botcore.utils.logging import get_logger
+from botcore.utils.scheduling import create_task
 from disnake.ext import commands
 
 from bot import constants
@@ -16,8 +17,8 @@ class SirRobin(commands.Bot):
         super().__init__(**kwargs)
         self.name = "Sir-Robin"
         self._guild_available = asyncio.Event()
-        self.loop.create_task(self.check_channels())
-        self.loop.create_task(self.send_log(self.name, "Connected!"))
+        create_task(self.check_channels(), event_loop=self.loop)
+        create_task(self.send_log(self.name, "Connected!"), event_loop=self.loop)
 
     def add_cog(self, cog: commands.Cog) -> None:
         """

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import disnake
 from botcore.utils.logging import get_logger
 from disnake.ext import commands
@@ -10,6 +12,13 @@ log = get_logger(__name__)
 class SirRobin(commands.Bot):
     """Sir-Robin core."""
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.name = "Sir-Robin"
+        self._guild_available = asyncio.Event()
+        self.loop.create_task(self.check_channels())
+        self.loop.create_task(self.send_log(self.name, "Connected!"))
+
     def add_cog(self, cog: commands.Cog) -> None:
         """
         Delegate to super to register `cog`.
@@ -18,6 +27,74 @@ class SirRobin(commands.Bot):
         """
         super().add_cog(cog)
         log.info(f"Cog loaded: {cog.qualified_name}")
+
+    async def check_channels(self) -> None:
+        """Verifies that all channel constants refer to channels which exist."""
+        await self.wait_until_guild_available()
+
+        if constants.Client.debug:
+            log.info("Skipping Channels Check.")
+            return
+
+        all_channels_ids = [channel.id for channel in self.get_all_channels()]
+        for name, channel_id in vars(constants.Channels).items():
+            if name.startswith("_"):
+                continue
+            if channel_id not in all_channels_ids:
+                log.error(f'Channel "{name}" with ID {channel_id} missing')
+
+    async def send_log(self, title: str, details: str = None, *, icon: str = None) -> None:
+        """Send an embed message to the devlog channel."""
+        await self.wait_until_guild_available()
+        devlog = self.get_channel(constants.Channels.devlog)
+
+        if not devlog:
+            log.info(f"Fetching devlog channel as it wasn't found in the cache (ID: {constants.Channels.devlog})")
+            try:
+                devlog = await self.fetch_channel(constants.Channels.devlog)
+            except disnake.HTTPException as disnake_exc:
+                log.exception("Fetch failed", exc_info=disnake_exc)
+                return
+
+        if not icon:
+            icon = self.user.display_avatar.url
+
+        embed = disnake.Embed(description=details)
+        embed.set_author(name=title, icon_url=icon)
+
+        await devlog.send(embed=embed)
+
+    async def on_guild_available(self, guild: disnake.Guild) -> None:
+        """
+        Set the internal `_guild_available` event when PyDis guild becomes available.
+
+        If the cache appears to still be empty (no members, no channels, or no roles), the event
+        will not be set.
+        """
+        if guild.id != constants.Client.guild:
+            return
+
+        if not guild.roles or not guild.members or not guild.channels:
+            log.warning("Guild available event was dispatched but the cache appears to still be empty!")
+            return
+
+        self._guild_available.set()
+
+    async def on_guild_unavailable(self, guild: disnake.Guild) -> None:
+        """Clear the internal `_guild_available` event when PyDis guild becomes unavailable."""
+        if guild.id != constants.Client.guild:
+            return
+
+        self._guild_available.clear()
+
+    async def wait_until_guild_available(self) -> None:
+        """
+        Wait until the PyDis guild becomes available (and the cache is ready).
+
+        The on_ready event is inadequate because it only waits 2 seconds for a GUILD_CREATE
+        gateway event before giving up and thus not populating the cache for unavailable guilds.
+        """
+        await self._guild_available.wait()
 
 
 bot = SirRobin(command_prefix=constants.Client.prefix, activity=disnake.Game("The Not-Quite-So-Bot-as-Sir-Lancebot"))

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -4,6 +4,7 @@ from typing import NamedTuple
 
 class Channels(NamedTuple):
     bot_commands = 267659945086812160
+    devlog = int(environ.get("CHANNEL_DEVLOG", 622895325144940554))
     sir_lancebot_playground = int(environ.get("CHANNEL_COMMUNITY_BOT_COMMANDS", 607247579608121354))
 
 


### PR DESCRIPTION
Per a convo with @ToxicKidz, added `wait_until_guild_read` and the `send_log` method to the bot. 

[message](https://discord.com/channels/267624335836053506/943526620940083220/947328378925613107)