### PR TITLE
Bump status embed version to reduce args

### DIFF
--- a/.github/workflows/status_embed.yaml
+++ b/.github/workflows/status_embed.yaml
@@ -55,21 +55,11 @@ jobs:
       # more information and we can fine tune when we actually want
       # to send an embed.
       - name: GitHub Actions Status Embed for Discord
-        uses: SebastiaanZ/github-status-embed-for-discord@v0.2.1
+        uses: SebastiaanZ/github-status-embed-for-discord@v0.3.0
         with:
           # Our GitHub Actions webhook
           webhook_id: '784184528997842985'
           webhook_token: ${{ secrets.GHA_WEBHOOK_TOKEN }}
-
-          # Workflow information
-          workflow_name: ${{ github.event.workflow_run.name }}
-          run_id: ${{ github.event.workflow_run.id }}
-          run_number: ${{ github.event.workflow_run.run_number }}
-          status: ${{ github.event.workflow_run.conclusion }}
-          actor: ${{ github.actor }}
-          repository:  ${{ github.repository }}
-          ref: ${{ github.ref }}
-          sha: ${{ github.event.workflow_run.head_sha }}
 
           pr_author_login: ${{ steps.pr_info.outputs.pr_author_login }}
           pr_number: ${{ steps.pr_info.outputs.pr_number }}


### PR DESCRIPTION
In 0.3.0 Seb's status embed action pulls the meta data driectly from the github object, so there is no need to pass it in