### PR TITLE
Patch Sir Robin to use a task to load in extensions

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -28,13 +28,16 @@ class SirRobin(commands.Bot):
         await super().add_cog(cog, **kwargs)
         log.info(f"Cog loaded: {cog.qualified_name}")
 
-    async def setup_hook(self) -> None:
-        """Default Async initialisation method for Discord.py."""
-        create_task(self.check_channels(), event_loop=self.loop)
-        create_task(self.send_log(constants.Client.name, "Connected!"), event_loop=self.loop)
-
+    async def load_all_extensions(self) -> None:
+        """Loads all the extensions in the `exts` module."""
         for ext in walk_extensions(exts):
             await self.load_extension(ext)
+
+    async def setup_hook(self) -> None:
+        """Default Async initialisation method for Discord.py."""
+        create_task(self.load_all_extensions(), event_loop=self.loop)
+        create_task(self.check_channels(), event_loop=self.loop)
+        create_task(self.send_log(constants.Client.name, "Connected!"), event_loop=self.loop)
 
     async def check_channels(self) -> None:
         """Verifies that all channel constants refer to channels which exist."""


### PR DESCRIPTION
Just a tiny PR to make extension loading compatible with Cogs that call `wait_until..` by themselves.