### PR TITLE
Feat/zen command

### DIFF
--- a/bot/exts/error_handler.py
+++ b/bot/exts/error_handler.py
@@ -1,5 +1,6 @@
 from discord import Colour, Embed
-from discord.ext.commands import BadArgument, Cog, CommandError, CommandNotFound, Context
+from discord.ext.commands import (BadArgument, Cog, CommandError,
+                                  CommandNotFound, Context)
 
 from bot.bot import SirRobin
 from bot.log import get_logger
@@ -24,7 +25,8 @@ class ErrorHandler(Cog):
 
     @Cog.listener()
     async def on_command_error(self, ctx: Context, error: CommandError) -> None:
-        """Generic command error handling from other cogs.
+        """
+        Generic command error handling from other cogs.
 
         Using the error type, handle the error appropriately.
             if there is no handling for the error type raised,

--- a/bot/exts/error_handler.py
+++ b/bot/exts/error_handler.py
@@ -1,6 +1,7 @@
 from discord import Colour, Embed
 from discord.ext.commands import (BadArgument, Cog, CommandError,
-                                  CommandNotFound, Context)
+                                  CommandNotFound, Context,
+                                  MissingRequiredArgument)
 
 from bot.bot import SirRobin
 from bot.log import get_logger
@@ -37,12 +38,19 @@ class ErrorHandler(Cog):
         """
         log.trace(f"Handling a raised error {error} from {ctx.command}")
 
+        # We could handle the subclasses of UserInputError errors together, using the error
+        # name as the embed title. Before doing this we would have to verify that all messages
+        # attached to subclasses of this error are human-readable, as they are user facing.
         if isinstance(error, BadArgument):
             embed = self._get_error_embed("Bad argument", str(error))
             await ctx.send(embed=embed)
             return
         elif isinstance(error, CommandNotFound):
             embed = self._get_error_embed("Command not found", str(error))
+            await ctx.send(embed=embed)
+            return
+        elif isinstance(error, MissingRequiredArgument):
+            embed = self._get_error_embed("Missing required argument", str(error))
             await ctx.send(embed=embed)
             return
 

--- a/bot/exts/error_handler.py
+++ b/bot/exts/error_handler.py
@@ -1,0 +1,57 @@
+from discord import Colour, Embed
+from discord.ext.commands import BadArgument, Cog, CommandError, CommandNotFound, Context
+
+from bot.bot import SirRobin
+from bot.log import get_logger
+
+log = get_logger(__name__)
+
+
+class ErrorHandler(Cog):
+    """Handles errors emitted from commands."""
+
+    def __init__(self, bot: SirRobin):
+        self.bot = bot
+
+    @staticmethod
+    def _get_error_embed(title: str, body: str) -> Embed:
+        """Return a embed with our error colour assigned."""
+        return Embed(
+            title=title,
+            colour=Colour.brand_red(),
+            description=body
+        )
+
+    @Cog.listener()
+    async def on_command_error(self, ctx: Context, error: CommandError) -> None:
+        """Generic command error handling from other cogs.
+
+        Using the error type, handle the error appropriately.
+            if there is no handling for the error type raised,
+            a message will be sent to the user & it will be logged.
+
+        In the future, I would expect this to be used as a place
+            to push errors to a sentry instance.
+        """
+        log.trace(f"Handling a raised error {error} from {ctx.command}")
+
+        if isinstance(error, BadArgument):
+            embed = self._get_error_embed("Bad argument", str(error))
+            await ctx.send(embed=embed)
+            return
+        elif isinstance(error, CommandNotFound):
+            embed = self._get_error_embed("Command not found", str(error))
+            await ctx.send(embed=embed)
+            return
+
+        # If we haven't handled it by this point, it is considered an unexpected/handled error.
+        await ctx.send(
+            f"Sorry, an unexpected error occurred. Please let us know!\n\n"
+            f"```{error.__class__.__name__}: {error}```"
+        )
+        log.error(f"Error executing command invoked by {ctx.message.author}: {ctx.message.content}", exc_info=error)
+
+
+async def setup(bot: SirRobin) -> None:
+    """Load the ErrorHandler cog."""
+    await bot.add_cog(ErrorHandler(bot))

--- a/bot/exts/miscellaneous.py
+++ b/bot/exts/miscellaneous.py
@@ -21,14 +21,14 @@ Readability is for hobgoblins.
 Special cases will be met with the full force of the PSF.
 Purity beats practicality.
 There are no errors.
-Anyone who says there are errors will be explicitly   silenced.
+Anyone who says there are errors will be explicitly silenced.
 In the face of ambiguity, remove the freedom to guess.
 There is only one way to do it.
-Although that way may not be obvious at first unless   you're Dutch.
+Although that way may not be obvious at first unless you're Dutch.
 Now is better than never.
 Although never is not real because time is fake.
-If the implementation is hard to explain, it's a bad   idea.
-If the implementation is compliant with this style   guide, it is a great idea.
+If the implementation is hard to explain, it's a bad idea.
+If the implementation is compliant with this style guide, it is a great idea
 Namespaces may contribute towards the 120 character minimum — let’s do more of those!
 """
 

--- a/bot/exts/miscellaneous.py
+++ b/bot/exts/miscellaneous.py
@@ -106,5 +106,5 @@ class Miscellaneous(commands.Cog):
 
 
 async def setup(bot: SirRobin) -> None:
-    """Load the Ping cog."""
+    """Load the Miscellaneous cog."""
     await bot.add_cog(Miscellaneous(bot))

--- a/bot/exts/miscellaneous.py
+++ b/bot/exts/miscellaneous.py
@@ -1,0 +1,110 @@
+import difflib
+from typing import Union
+
+from botcore.utils.logging import get_logger
+from discord import Colour, Embed
+from discord.ext import commands
+from discord.ext.commands import BadArgument
+
+from bot.bot import SirRobin
+
+log = get_logger(__name__)
+
+ZEN_OF_PYTHON = """\
+Beautiful is better than ugly.
+Explicit is better than implicit.
+Simple is better than complex.
+Complex is better than complicated.
+Flat is better than nested.
+Sparse is better than dense.
+Readability is for hobgoblins.
+Special cases will be met with the full force of the PSF.
+Purity beats practicality.
+There are no errors.
+Anyone who says there are errors will be explicitly   silenced.
+In the face of ambiguity, remove the freedom to guess.
+There is only one way to do it.
+Although that way may not be obvious at first unless   you're Dutch.
+Now is better than never.
+Although never is not real because time is fake.
+If the implementation is hard to explain, it's a bad   idea.
+If the implementation is compliant with this style   guide, it is a great idea.
+Namespaces may contribute towards the 120 character minimum — let’s do more of those!
+"""
+
+
+class Miscellaneous(commands.Cog):
+    """A grouping of commands that are small and have unique but unrelated usages."""
+
+    def __init__(self, bot: SirRobin):
+        self.bot = bot
+
+    @commands.command()
+    async def zen(self, ctx: commands.Context, *, search_value: Union[int, str, None] = None) -> None:
+        """Display the Zen of Python in an embed."""
+        embed = Embed(
+            colour=Colour.og_blurple(),
+            title="The Zen of Python",
+            description=ZEN_OF_PYTHON
+        )
+
+        if search_value is None:
+            embed.title += ", by Tim Peters"
+            await ctx.send(embed=embed)
+            return
+
+        zen_lines = ZEN_OF_PYTHON.splitlines()
+
+        # handle if it's an index int
+        if isinstance(search_value, int):
+            upper_bound = len(zen_lines) - 1
+            lower_bound = -1 * len(zen_lines)
+            if not (lower_bound <= search_value <= upper_bound):
+                raise BadArgument(f"Please provide an index between {lower_bound} and {upper_bound}.")
+
+            embed.title += f" (line {search_value % len(zen_lines)}):"
+            embed.description = zen_lines[search_value]
+            await ctx.send(embed=embed)
+            return
+
+        # Try to handle first exact word due difflib.SequenceMatched may use some other similar word instead
+        # exact word.
+        for i, line in enumerate(zen_lines):
+            for word in line.split():
+                if word.lower() == search_value.lower():
+                    embed.title += f" (line {i}):"
+                    embed.description = line
+                    await ctx.send(embed=embed)
+                    return
+
+        # handle if it's a search string and not exact word
+        matcher = difflib.SequenceMatcher(None, search_value.lower())
+
+        best_match = ""
+        match_index = 0
+        best_ratio = 0
+
+        for index, line in enumerate(zen_lines):
+            matcher.set_seq2(line.lower())
+
+            # the match ratio needs to be adjusted because, naturally,
+            # longer lines will have worse ratios than shorter lines when
+            # fuzzy searching for keywords. this seems to work okay.
+            adjusted_ratio = (len(line) - 5) ** 0.5 * matcher.ratio()
+
+            if adjusted_ratio > best_ratio:
+                best_ratio = adjusted_ratio
+                best_match = line
+                match_index = index
+
+        if not best_match:
+            raise BadArgument("I didn't get a match! Please try again with a different search term.")
+
+        embed.title += f" (line {match_index}):"
+        embed.description = best_match
+        await ctx.send(embed=embed)
+
+
+async def setup(bot: SirRobin) -> None:
+    """Load the Ping cog."""
+    await bot.add_cog(Miscellaneous(bot))


### PR DESCRIPTION
This PR adds two main things.

### Miscellaneous cog
This is used to group commands that are small & unique but unrelated usages. 
This is where I have ported the [original code](https://github.com/python-discord/bot/blob/93fafa22e3a01583fe4e5c232f1cef03d7b289ff/bot/exts/utils/utils.py#L89-L157) to.

### Error handling cog
The zen implementation relies heavily on an error handling cog. I have implemented a simple one that
can be extended as this project grows. I do not think this PR should add any more handlers that the 
ones I have added.


### Zen Command in action
#### & zen
![image](https://user-images.githubusercontent.com/57012020/161050137-fc6d4b65-48c8-4ec4-9251-a143452f6405.png)
#### &zen int
![image](https://user-images.githubusercontent.com/57012020/161050168-45c84a3c-c71f-4f7a-8489-0255a24ed846.png)
#### &zen string
![image](https://user-images.githubusercontent.com/57012020/161050305-03de4fa8-932e-4695-9249-6da7f9281bf3.png)
#### &zen zzzzzzzzzzzzzzzzzz
![image](https://user-images.githubusercontent.com/57012020/161050219-5ba1b751-c8d9-404d-92f4-a661b4856477.png)
