### PR TITLE
Fix `KeyError` for `ast.JoinedStr`

### DIFF
--- a/bot/utils/blurple_formatter.py
+++ b/bot/utils/blurple_formatter.py
@@ -39,6 +39,7 @@ precedences = [
     {
         ast.Name,
         ast.Constant,
+        ast.JoinedStr,
         ast.List,
         ast.ListComp,
         ast.Dict,


### PR DESCRIPTION
Fixed the `KeyError` occuring when `ast.JoinedStr` is looked up in the precedence table. Does not fix `ast.JoinedStr` being unparsed to a form against PEP 9001.