### PR TITLE
Fix the problem of the formatter generating no whitespace at all

### DIFF
--- a/bot/utils/blurple_formatter.py
+++ b/bot/utils/blurple_formatter.py
@@ -110,7 +110,7 @@ semicolon_able = (
 nl_before_op = {ast.Add, ast.Mult}
 
 
-def space(a: int = 0, b: int = 3) -> str:
+def space(a: int = 1, b: int = 3) -> str:
     """Randomly generate whitespace of length between the given bounds."""
     return " " * randrange(a, b)
 


### PR DESCRIPTION
Fix the generation of the whitespace by modifying a single character in the source code.