### PR TITLE
Port hastebin to Sir Robin

### DIFF
--- a/bot/exts/blurple_formatter.py
+++ b/bot/exts/blurple_formatter.py
@@ -2,11 +2,14 @@ import asyncio
 import traceback
 
 import discord
+from botcore.utils.logging import get_logger
 from botcore.utils.regex import FORMATTED_CODE_REGEX
 from discord.ext import commands
 
 from bot.bot import SirRobin
-from bot.utils import blurple_formatter
+from bot.utils import blurple_formatter, services
+
+log = get_logger(__name__)
 
 
 class BlurpleFormatter(commands.Cog):
@@ -36,6 +39,15 @@ class BlurpleFormatter(commands.Cog):
                 color=0xCD6D6D,
             )
             await ctx.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+            return
+
+        if len(blurpified) > 2000:
+            paste = await services.send_to_paste_service(blurpified)
+            if not paste:
+                await ctx.send(":warning: Failed to upload full output")
+            else:
+                await ctx.send(f":white_check_mark: Formatted code too big, full output: {paste}")
+
             return
 
         await ctx.send(f"```py\n{blurpified}\n```", allowed_mentions=discord.AllowedMentions.none())

--- a/bot/exts/blurple_formatter.py
+++ b/bot/exts/blurple_formatter.py
@@ -2,14 +2,11 @@ import asyncio
 import traceback
 
 import discord
-from botcore.utils.logging import get_logger
 from botcore.utils.regex import FORMATTED_CODE_REGEX
 from discord.ext import commands
 
 from bot.bot import SirRobin
 from bot.utils import blurple_formatter, services
-
-log = get_logger(__name__)
 
 
 class BlurpleFormatter(commands.Cog):

--- a/bot/utils/services.py
+++ b/bot/utils/services.py
@@ -14,8 +14,9 @@ PASTE_SERVICE = "https://paste.pythondiscord.com/{key}"
 async def send_to_paste_service(contents: str, *, extension: str = "") -> Optional[str]:
     """
     Upload `contents` to the paste service.
-    `extension` is added to the output URL
-    When an error occurs, `None` is returned, otherwise the generated URL with the suffix.
+
+    `extension` is added to the output URL before being returned. When an error occurs,
+    `None` is returned, otherwise the generated URL with the suffix.
     """
     extension = extension and f".{extension}"
     log.debug(f"Sending contents of size {len(contents.encode())} bytes to paste service.")

--- a/bot/utils/services.py
+++ b/bot/utils/services.py
@@ -1,0 +1,59 @@
+from typing import Optional
+
+from aiohttp import ClientConnectorError
+from botcore.utils.logging import get_logger
+
+from bot.bot import bot
+
+log = get_logger(__name__)
+
+FAILED_REQUEST_ATTEMPTS = 3
+PASTE_SERVICE = "https://paste.pythondiscord.com/{key}"
+
+
+async def send_to_paste_service(contents: str, *, extension: str = "") -> Optional[str]:
+    """
+    Upload `contents` to the paste service.
+    `extension` is added to the output URL
+    When an error occurs, `None` is returned, otherwise the generated URL with the suffix.
+    """
+    extension = extension and f".{extension}"
+    log.debug(f"Sending contents of size {len(contents.encode())} bytes to paste service.")
+    paste_url = PASTE_SERVICE.format(key="documents")
+    for attempt in range(1, FAILED_REQUEST_ATTEMPTS + 1):
+        try:
+            async with bot.http_session.post(paste_url, data=contents) as response:
+                response_json = await response.json()
+        except ClientConnectorError:
+            log.warning(
+                f"Failed to connect to paste service at url {paste_url}, "
+                f"trying again ({attempt}/{FAILED_REQUEST_ATTEMPTS})."
+            )
+            continue
+        except Exception:
+            log.exception(
+                f"An unexpected error has occurred during handling of the request, "
+                f"trying again ({attempt}/{FAILED_REQUEST_ATTEMPTS})."
+            )
+            continue
+
+        if "message" in response_json:
+            log.warning(
+                f"Paste service returned error {response_json['message']} with status code {response.status}, "
+                f"trying again ({attempt}/{FAILED_REQUEST_ATTEMPTS})."
+            )
+            continue
+        elif "key" in response_json:
+            log.info(f"Successfully uploaded contents to paste service behind key {response_json['key']}.")
+
+            paste_link = PASTE_SERVICE.format(key=response_json['key']) + extension
+
+            if extension == '.py':
+                return paste_link
+
+            return paste_link + "?noredirect"
+
+        log.warning(
+            f"Got unexpected JSON response from paste service: {response_json}\n"
+            f"trying again ({attempt}/{FAILED_REQUEST_ATTEMPTS})."
+        )


### PR DESCRIPTION
Formatted code can become longer than its input, this means that the message sent may go over the 2000-character limit.

This PR ports over the bot service file and puts it to good use in the blurple formatter.