### PR TITLE
Add support for viewing and adding CJ Infractions notes

### DIFF
--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -16,7 +16,8 @@ from bot.constants import Roles
 from bot.exts.code_jams import _creation_utils
 from bot.exts.code_jams._flows import (creation_flow, deletion_flow, move_flow,
                                        remove_flow)
-from bot.exts.code_jams._views import JamConfirmation, JamTeamInfoConfirmation
+from bot.exts.code_jams._views import (JamConfirmation, JamInfoView,
+                                       JamTeamInfoConfirmation)
 from bot.services import send_to_paste_service
 
 log = get_logger(__name__)
@@ -159,8 +160,7 @@ class CodeJams(commands.Cog):
                 colour=Colour.og_blurple()
             )
             embed.add_field(name="Team", value=team["team"]["name"], inline=True)
-
-            await ctx.send(embed=embed)
+            await ctx.send(embed=embed, view=JamInfoView(member, self.bot.code_jam_mgmt_api))
 
     @codejam.command()
     @commands.has_any_role(Roles.admins, Roles.events_lead)

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -162,7 +162,7 @@ class CodeJams(commands.Cog):
                 colour=Colour.og_blurple()
             )
             embed.add_field(name="Team", value=team["team"]["name"], inline=True)
-            await ctx.send(embed=embed, view=JamInfoView(member, self.bot.code_jam_mgmt_api))
+            await ctx.send(embed=embed, view=JamInfoView(member, self.bot.code_jam_mgmt_api, ctx.author))
 
     @codejam.command()
     @commands.has_any_role(Roles.admins, Roles.events_lead)

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -162,6 +162,7 @@ class CodeJams(commands.Cog):
                 colour=Colour.og_blurple()
             )
             embed.add_field(name="Team", value=team["team"]["name"], inline=True)
+            embed.add_field(name="Team leader", value="Yes" if team["is_leader"] else "No", inline=True)
             await ctx.send(embed=embed, view=JamInfoView(member, self.bot.code_jam_mgmt_api, ctx.author))
 
     @codejam.command()

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -14,17 +14,10 @@ from discord.ext import commands
 from bot.bot import SirRobin
 from bot.constants import Roles
 from bot.exts.code_jams import _creation_utils
-from bot.exts.code_jams._flows import (
-    creation_flow,
-    deletion_flow,
-    move_flow,
-    remove_flow
-)
-from bot.exts.code_jams._views import (
-    JamConfirmation,
-    JamInfoView,
-    JamTeamInfoConfirmation
-)
+from bot.exts.code_jams._flows import (creation_flow, deletion_flow, move_flow,
+                                       remove_flow)
+from bot.exts.code_jams._views import (JamConfirmation, JamInfoView,
+                                       JamTeamInfoConfirmation)
 from bot.services import send_to_paste_service
 
 log = get_logger(__name__)

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -14,10 +14,17 @@ from discord.ext import commands
 from bot.bot import SirRobin
 from bot.constants import Roles
 from bot.exts.code_jams import _creation_utils
-from bot.exts.code_jams._flows import (creation_flow, deletion_flow, move_flow,
-                                       remove_flow)
-from bot.exts.code_jams._views import (JamConfirmation, JamInfoView,
-                                       JamTeamInfoConfirmation)
+from bot.exts.code_jams._flows import (
+    creation_flow,
+    deletion_flow,
+    move_flow,
+    remove_flow
+)
+from bot.exts.code_jams._views import (
+    JamConfirmation,
+    JamInfoView,
+    JamTeamInfoConfirmation
+)
 from bot.services import send_to_paste_service
 
 log = get_logger(__name__)
@@ -146,8 +153,10 @@ class CodeJams(commands.Cog):
         The team is found by issuing a request to the CJ Management System
         """
         try:
-            team = await self.bot.code_jam_mgmt_api.get(f"users/{member.id}/current_team",
-                                                        raise_for_status=True)
+            team = await self.bot.code_jam_mgmt_api.get(
+                f"users/{member.id}/current_team",
+                raise_for_status=True
+            )
         except ResponseCodeError as err:
             if err.response.status == 404:
                 await ctx.send(":x: It seems like the user is not a participant!")

--- a/bot/exts/code_jams/_creation_utils.py
+++ b/bot/exts/code_jams/_creation_utils.py
@@ -4,6 +4,7 @@ import discord
 from botcore.utils.logging import get_logger
 
 from bot.constants import Channels, Roles
+from bot.utils.exceptions import JamCategoryNameConflictError
 
 log = get_logger(__name__)
 
@@ -19,7 +20,6 @@ async def _create_category(guild: discord.Guild) -> discord.CategoryChannel:
         guild.default_role: discord.PermissionOverwrite(read_messages=False),
         guild.me: discord.PermissionOverwrite(read_messages=True)
     }
-
     category = await guild.create_category_channel(
         CATEGORY_NAME,
         overwrites=category_overwrites,
@@ -38,7 +38,13 @@ async def _get_category(guild: discord.Guild) -> discord.CategoryChannel:
     Return a code jam category.
 
     If all categories are full or none exist, create a new category.
+    If the main CJ category and the CJ Team's category has the same name
+    it raises a `JamCategoryNameConflictError`
     """
+    main_cj_category = guild.get_channel(Channels.summer_code_jam).name
+    if main_cj_category == CATEGORY_NAME:
+        raise JamCategoryNameConflictError()
+
     for category in guild.categories:
         if category.name == CATEGORY_NAME and len(category.channels) < MAX_CHANNELS:
             return category

--- a/bot/exts/code_jams/_views.py
+++ b/bot/exts/code_jams/_views.py
@@ -161,6 +161,7 @@ class JamConfirmation(discord.ui.View):
         return True
 
     async def on_error(self, error: Exception, item: discord.ui.Item[Any], interaction: discord.Interaction) -> None:
+        """Discord.py default to handle a view error."""
         if isinstance(error, JamCategoryNameConflictError):
             await interaction.channel.send(
                 ":x: Due to a conflict regarding the names of the main Code Jam Category and the Code Jam Team category"

--- a/bot/exts/code_jams/_views.py
+++ b/bot/exts/code_jams/_views.py
@@ -223,10 +223,11 @@ class JamInfoView(discord.ui.View):
     Additionally, notes for a participant can be added and viewed.
     """
 
-    def __init__(self, member: discord.Member, mgmt_client: APIClient):
+    def __init__(self, member: discord.Member, mgmt_client: APIClient, author: discord.Member):
         super().__init__(timeout=900)
         self.mgmt_client = mgmt_client
         self.member = member
+        self.author = author
 
     @discord.ui.button(label='Add Note', style=discord.ButtonStyle.green)
     async def add_note(self, button: discord.ui.Button, interaction: discord.Interaction) -> None:
@@ -259,7 +260,7 @@ class JamInfoView(discord.ui.View):
 
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         """Global check to ensure the interacting user is an admin."""
-        if interaction.guild.get_role(Roles.admins) in interaction.user.roles:
+        if interaction.guild.get_role(Roles.admins) in interaction.user.roles or interaction.user == self.author:
             return True
         await interaction.response.send_message(
             ":x: You don't have permission to interact with this view!",

--- a/bot/exts/code_jams/_views.py
+++ b/bot/exts/code_jams/_views.py
@@ -169,8 +169,7 @@ class JamConfirmation(discord.ui.View):
             )
         else:
             await interaction.channel.send(
-                ":x: Something went wrong when confirming the view. Full details have been logged.",
-                ephemeral=True
+                ":x: Something went wrong when confirming the view. Full details have been logged."
             )
             log.error(f"Something went wrong: {error}")
 

--- a/bot/utils/exceptions.py
+++ b/bot/utils/exceptions.py
@@ -1,0 +1,4 @@
+class JamCategoryNameConflictError(Exception):
+    """Raised when upon creating a CodeJam the main jam category and the teams' category conflict."""
+
+    pass


### PR DESCRIPTION
- From now on the `cj info` command has a view attached to it. You can either view all the notes added to the specific participant, or you can add one. Adding a note is accomplished by triggering a modal from the view, which then calls the code jam management api on submission.A new kind of interaction check has been implemented for this view, since from now on, all of the admins can use the view regardless of the original author.