### PR TITLE
Remove CJ role check from the CJ command group.

### DIFF
--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -30,7 +30,6 @@ class CodeJams(commands.Cog):
         self.bot = bot
 
     @commands.group(aliases=("cj", "jam"))
-    @commands.has_any_role(Roles.admins, Roles.events_lead)
     async def codejam(self, ctx: commands.Context) -> None:
         """A Group of commands for managing Code Jams."""
         if ctx.invoked_subcommand is None:


### PR DESCRIPTION
We have command level role locks, so that is unnecessary, this way the info command can be used by the Events Team.