### PR TITLE
Add `cj pin` and `cj unpin`

### DIFF
--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -188,11 +188,13 @@ class CodeJams(commands.Cog):
     @codejam.command()
     @commands.has_any_role(Roles.admins, Roles.events_lead, Roles.code_jam_event_team, Roles.code_jam_participants)
     @in_code_jam_category(_creation_utils.CATEGORY_NAME)
-    async def pin(self, ctx: commands.Context) -> None:
+    async def pin(self, ctx: commands.Context, message: Optional[discord.Message]) -> None:
         """Lets Code Jam Participants to pin messages in their team channels."""
-        referenced_message = getattr(ctx.message.reference, "resolved", None)
+        referenced_message = getattr(ctx.message.reference, "resolved", None) or message
         if not isinstance(referenced_message, discord.Message):
-            await ctx.reply(":x: You have to reply to a message in order to pin it!")
+            await ctx.reply(
+                ":x: You have to either reply to a message or provide a message link / message id in order to pin it."
+            )
             return
 
         if referenced_message.pinned:
@@ -219,11 +221,13 @@ class CodeJams(commands.Cog):
     @codejam.command()
     @commands.has_any_role(Roles.admins, Roles.events_lead, Roles.code_jam_event_team, Roles.code_jam_participants)
     @in_code_jam_category(_creation_utils.CATEGORY_NAME)
-    async def unpin(self, ctx: commands.Context) -> None:
+    async def unpin(self, ctx: commands.Context, message: Optional[discord.Message]) -> None:
         """Lets Code Jam Participants to unpin messages in their team channels."""
-        referenced_message = getattr(ctx.message.reference, "resolved", None)
+        referenced_message = getattr(ctx.message.reference, "resolved", None) or message
         if not isinstance(referenced_message, discord.Message):
-            await ctx.reply(":x: You have to reply to a message in order to unpin it!")
+            await ctx.reply(
+                ":x: You have to either reply to a message or provide a message link / message id in order to unpin it."
+            )
             return
 
         if not referenced_message.pinned:

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -15,7 +15,7 @@ from bot.bot import SirRobin
 from bot.constants import Roles
 from bot.exts.code_jams import _creation_utils
 from bot.exts.code_jams._flows import (creation_flow, deletion_flow, move_flow,
-                                       remove_flow, pin_flow)
+                                       pin_flow, remove_flow)
 from bot.exts.code_jams._views import (JamConfirmation, JamInfoView,
                                        JamTeamInfoConfirmation)
 from bot.services import send_to_paste_service

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -219,7 +219,6 @@ class CodeJams(commands.Cog):
             else:
                 await ctx.reply("Something went wrong while processing the request! We have notified the team!")
                 log.error(f"Something went wrong with processing the request! {err}")
-            return
         else:
             if ctx.channel.id == int(team["team"]["discord_channel_id"]) \
                     and message.channel.id == int(team["team"]["discord_channel_id"]):
@@ -260,7 +259,6 @@ class CodeJams(commands.Cog):
             else:
                 await ctx.reply("Something went wrong while processing the request! We have notified the team!")
                 log.error(f"Something went wrong with processing the request! {err}")
-            return
         else:
             if ctx.channel.id == int(team["team"]["discord_channel_id"]) \
                     and message.channel.id == int(team["team"]["discord_channel_id"]):

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -191,6 +191,7 @@ class CodeJams(commands.Cog):
     async def pin(self, ctx: commands.Context, message: Optional[discord.Message]) -> None:
         """Lets Code Jam Participants to pin messages in their team channels."""
         referenced_message = getattr(ctx.message.reference, "resolved", None) or message
+        roles = (Roles.admins, Roles.code_jam_event_team)
         if not isinstance(referenced_message, discord.Message):
             await ctx.reply(
                 ":x: You have to either reply to a message or provide a message link / message id in order to pin it."
@@ -199,6 +200,9 @@ class CodeJams(commands.Cog):
 
         if referenced_message.pinned:
             await ctx.reply(":x: The message has already been pinned!")
+            return
+        if any(role.id in roles for role in getattr(ctx.author, "roles", [])):
+            await _creation_utils.pin_message(referenced_message, ctx)
             return
         try:
             team = await self.bot.code_jam_mgmt_api.get(
@@ -224,6 +228,7 @@ class CodeJams(commands.Cog):
     async def unpin(self, ctx: commands.Context, message: Optional[discord.Message]) -> None:
         """Lets Code Jam Participants to unpin messages in their team channels."""
         referenced_message = getattr(ctx.message.reference, "resolved", None) or message
+        roles = (Roles.admins, Roles.code_jam_event_team)
         if not isinstance(referenced_message, discord.Message):
             await ctx.reply(
                 ":x: You have to either reply to a message or provide a message link / message id in order to unpin it."
@@ -232,6 +237,9 @@ class CodeJams(commands.Cog):
 
         if not referenced_message.pinned:
             await ctx.reply(":x: The message has already been unpinned!")
+            return
+        if any(role.id in roles for role in getattr(ctx.author, "roles", [])):
+            await _creation_utils.pin_message(referenced_message, ctx, unpin=True)
             return
         try:
             team = await self.bot.code_jam_mgmt_api.get(

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -238,11 +238,9 @@ class CodeJams(commands.Cog):
             else:
                 if ctx.channel.id == int(team["team"]["discord_channel_id"]):
                     await _creation_utils.pin_message(referenced_message, ctx, unpin=True)
-                else:
-                    await ctx.reply("You don't have permission to pin this message in this channel!")
 
         else:
-            await ctx.reply(":x: You have to reply to a message in order to pin it!")
+            await ctx.reply(":x: You have to reply to a message in order to unpin it!")
 
     @staticmethod
     def jam_categories(guild: Guild) -> list[discord.CategoryChannel]:

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -138,7 +138,7 @@ class CodeJams(commands.Cog):
         await ctx.send("Code Jam has officially ended! :sunrise:")
 
     @codejam.command()
-    @commands.has_any_role(Roles.admins, Roles.events_lead)
+    @commands.has_any_role(Roles.admins, Roles.code_jam_event_team)
     async def info(self, ctx: commands.Context, member: Member) -> None:
         """
         Send an info embed about the member with the team they're in.

--- a/bot/exts/code_jams/_creation_utils.py
+++ b/bot/exts/code_jams/_creation_utils.py
@@ -130,17 +130,22 @@ async def _add_team_leader_roles(members: list[dict[str: discord.Member, str: bo
             await entry["member"].add_roles(team_leaders)
 
 
-async def pin_message(message: discord.Message, ctx: commands.Context, unpin: bool = False) -> None:
-    """A discord.py helper to pin or unpin messages and handle possible exceptions."""
+async def pin_message(message: discord.Message, ctx: commands.Context, unpin: bool) -> None:
+    """Pin `message` if `pin` is True or unpin if it's False."""
+    channel_str = f"#{message.channel} ({message.channel.id})"
+    func = message.unpin if unpin else message.pin
+
     try:
-        if unpin:
-            await message.unpin(reason="Code Jam organization")
-            await ctx.reply(":white_check_mark: The message has been unpinned!")
+        await func()
+    except discord.HTTPException as e:
+        if e.code == 10008:
+            log.debug(f"Message {message.id} in {channel_str} doesn't exist; can't {func.__name__}.")
         else:
-            await message.pin(reason="Code Jam organization")
-            await ctx.reply(":white_check_mark: The message has been pinned!")
-    except discord.HTTPException as err:
-        await ctx.reply(
-            f"Something went wrong {', you might have reached the 50 pins per channel limit!' if not unpin else ''}"
-        )
-        log.trace(f"Something went wrong when pinning a CJ message: {err}")
+            log.exception(
+                f"Error {func.__name__}ning message {message.id} in {channel_str}: "
+                f"{e.status} ({e.code})"
+            )
+            await ctx.reply(f":x: Something went wrong with {func.__name__}ing your message!")
+    else:
+        log.trace(f"{func.__name__.capitalize()}ned message {message.id} in {channel_str}.")
+        await ctx.reply(f":white_check_mark: Message has been {func.__name__}ed.")

--- a/bot/exts/code_jams/_creation_utils.py
+++ b/bot/exts/code_jams/_creation_utils.py
@@ -141,6 +141,6 @@ async def pin_message(message: discord.Message, ctx: commands.Context, unpin: bo
             await ctx.reply(":white_check_mark: The message has been pinned!")
     except discord.HTTPException as err:
         await ctx.reply(
-            f"Something went wrong, {'you might have reached the 50 pins per channel limit!' if not unpin else ''}"
+            f"Something went wrong {', you might have reached the 50 pins per channel limit!' if not unpin else ''}"
         )
-        log.trace(f"Something went wrong when pinng a CJ message: {err}")
+        log.trace(f"Something went wrong when pinning a CJ message: {err}")

--- a/bot/exts/code_jams/_creation_utils.py
+++ b/bot/exts/code_jams/_creation_utils.py
@@ -2,6 +2,7 @@ import typing as t
 
 import discord
 from botcore.utils.logging import get_logger
+from discord.ext import commands
 
 from bot.constants import Channels, Roles
 from bot.utils.exceptions import JamCategoryNameConflictError
@@ -127,3 +128,19 @@ async def _add_team_leader_roles(members: list[dict[str: discord.Member, str: bo
     for entry in members:
         if entry["is_leader"]:
             await entry["member"].add_roles(team_leaders)
+
+
+async def pin_message(message: discord.Message, ctx: commands.Context, unpin: bool = False) -> None:
+    """A discord.py helper to pin or unpin messages and handle possible exceptions."""
+    try:
+        if unpin:
+            await message.unpin(reason="Code Jam organization")
+            await ctx.reply(":white_check_mark: The message has been unpinned!")
+        else:
+            await message.pin(reason="Code Jam organization")
+            await ctx.reply(":white_check_mark: The message has been pinned!")
+    except discord.HTTPException as err:
+        await ctx.reply(
+            f"Something went wrong, {'you might have reached the 50 pins per channel limit!' if not unpin else ''}"
+        )
+        log.trace(f"Something went wrong when pinng a CJ message: {err}")

--- a/bot/exts/error_handler.py
+++ b/bot/exts/error_handler.py
@@ -5,6 +5,7 @@ from discord.ext.commands import (BadArgument, Cog, CommandError,
 
 from bot.bot import SirRobin
 from bot.log import get_logger
+from bot.utils.exceptions import CodeJamCategoryCheckFailure
 
 log = get_logger(__name__)
 
@@ -56,6 +57,10 @@ class ErrorHandler(Cog):
         elif isinstance(error, MissingAnyRole):
             embed = self._get_error_embed("Permission error", "You are not allowed to use this command!")
             await ctx.send(embed=embed)
+            return
+        elif isinstance(error, CodeJamCategoryCheckFailure):
+            # Silently fail, as SirRobin should not respond
+            # to any of the CJ related commands outside of the CJ categories.
             return
 
         # If we haven't handled it by this point, it is considered an unexpected/handled error.

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -1,0 +1,24 @@
+from typing import Callable, NoReturn, Union
+
+from discord.ext import commands
+
+from bot.log import get_logger
+from bot.utils.exceptions import CodeJamCategoryCheckFailure
+
+log = get_logger(__name__)
+
+
+def in_code_jam_category(code_jam_category_name: str) -> Callable:
+    """Raises `CodeJamCategoryCheckFailure` when the command is invoked outside of the Code Jam categories."""
+    async def predicate(ctx: commands.Context) -> Union[bool, NoReturn]:
+        if not ctx.guild:
+            return False
+        if not ctx.message.channel.category:
+            return False
+        code_jam_categories = filter(lambda category: category.name == code_jam_category_name, ctx.guild.categories)
+        if ctx.message.channel.category in code_jam_categories:
+            return True
+        log.trace(f"{ctx.author} tried to invoke {ctx.command.name} outside of the Code Jam categories.")
+        raise CodeJamCategoryCheckFailure()
+
+    return commands.check(predicate)

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -16,22 +16,9 @@ def in_code_jam_category(code_jam_category_name: str) -> Callable:
             return False
         if not ctx.message.channel.category:
             return False
-        code_jam_categories = filter(lambda category: category.name == code_jam_category_name, ctx.guild.categories)
-        if ctx.message.channel.category in code_jam_categories:
+        if ctx.message.channel.category.name == code_jam_category_name:
             return True
         log.trace(f"{ctx.author} tried to invoke {ctx.command.name} outside of the Code Jam categories.")
         raise CodeJamCategoryCheckFailure()
 
     return commands.check(predicate)
-
-
-def message_is_in_code_jam_category(
-        message: discord.Message,
-        code_jam_category_name: str,
-        ctx: commands.Context
-) -> bool:
-    """Returns True if the message's channel is in one of the Code Jam Categories."""
-    code_jam_categories = filter(lambda category: category.name == code_jam_category_name, ctx.guild.categories)
-    if message.channel.category in code_jam_categories:
-        return True
-    return False

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -1,6 +1,5 @@
 from typing import Callable, NoReturn, Union
 
-import discord
 from discord.ext import commands
 
 from bot.log import get_logger

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -1,5 +1,6 @@
 from typing import Callable, NoReturn, Union
 
+import discord
 from discord.ext import commands
 
 from bot.log import get_logger
@@ -22,3 +23,15 @@ def in_code_jam_category(code_jam_category_name: str) -> Callable:
         raise CodeJamCategoryCheckFailure()
 
     return commands.check(predicate)
+
+
+def message_is_in_code_jam_category(
+        message: discord.Message,
+        code_jam_category_name: str,
+        ctx: commands.Context
+) -> bool:
+    """Returns True if the message's channel is in one of the Code Jam Categories."""
+    code_jam_categories = filter(lambda category: category.name == code_jam_category_name, ctx.guild.categories)
+    if message.channel.category in code_jam_categories:
+        return True
+    return False

--- a/bot/utils/exceptions.py
+++ b/bot/utils/exceptions.py
@@ -1,4 +1,13 @@
+from discord.ext.commands import CheckFailure
+
+
 class JamCategoryNameConflictError(Exception):
     """Raised when upon creating a CodeJam the main jam category and the teams' category conflict."""
+
+    pass
+
+
+class CodeJamCategoryCheckFailure(CheckFailure):
+    """Raised when the specified command was run outside the Code Jam categories."""
 
     pass


### PR DESCRIPTION
Lets Code Jam participants pin messages in their own team channels. Check done via the Code Jam MGMT api.
Closes #53