### PR TITLE
Add `cj add` command and `add_flow` to the CJ exts stack

### DIFF
--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -14,8 +14,8 @@ from discord.ext import commands
 from bot.bot import SirRobin
 from bot.constants import Roles
 from bot.exts.code_jams import _creation_utils
-from bot.exts.code_jams._flows import (add_flow, creation_flow, deletion_flow, move_flow,
-                                       pin_flow, remove_flow)
+from bot.exts.code_jams._flows import (add_flow, creation_flow, deletion_flow,
+                                       move_flow, pin_flow, remove_flow)
 from bot.exts.code_jams._views import (JamConfirmation, JamInfoView,
                                        JamTeamInfoConfirmation)
 from bot.services import send_to_paste_service

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -178,8 +178,15 @@ class CodeJams(commands.Cog):
 
     @codejam.command()
     @commands.has_any_role(Roles.admins, Roles.events_lead)
-    async def add(self, ctx: commands.Context, member: Member, is_leader: bool = False, *, team_name: str) -> None:
-        """Add a member to the Code Jam by specifying the team's name, and whether they should be a leader."""
+    async def add(
+            self,
+            ctx: commands.Context,
+            member: Member,
+            is_leader: Optional[bool] = False,
+            *,
+            team_name: str
+    ) -> None:
+        """Add a member to the Code Jam by specifying the team's name, and whether they should be leaders."""
         callback = partial(add_flow, self.bot, team_name, ctx, member, is_leader)
         await ctx.send(
             f"Are you sure you want to add {member.mention} to {team_name}?",

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -14,7 +14,7 @@ from discord.ext import commands
 from bot.bot import SirRobin
 from bot.constants import Roles
 from bot.exts.code_jams import _creation_utils
-from bot.exts.code_jams._flows import (creation_flow, deletion_flow, move_flow,
+from bot.exts.code_jams._flows import (add_flow, creation_flow, deletion_flow, move_flow,
                                        pin_flow, remove_flow)
 from bot.exts.code_jams._views import (JamConfirmation, JamInfoView,
                                        JamTeamInfoConfirmation)
@@ -173,6 +173,16 @@ class CodeJams(commands.Cog):
         callback = partial(move_flow, self.bot, new_team_name, ctx, member)
         await ctx.send(
             f"Are you sure you want to move {member.mention} to {new_team_name}?",
+            view=JamConfirmation(author=ctx.author, callback=callback)
+        )
+
+    @codejam.command()
+    @commands.has_any_role(Roles.admins, Roles.events_lead)
+    async def add(self, ctx: commands.Context, member: Member, is_leader: bool = False, *, team_name: str) -> None:
+        """Add a member to the Code Jam by specifying the team's name, and whether they should be leaders."""
+        callback = partial(add_flow, self.bot, team_name, ctx, member, is_leader)
+        await ctx.send(
+            f"Are you sure you want to add {member.mention} to {team_name}?",
             view=JamConfirmation(author=ctx.author, callback=callback)
         )
 

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -179,7 +179,7 @@ class CodeJams(commands.Cog):
     @codejam.command()
     @commands.has_any_role(Roles.admins, Roles.events_lead)
     async def add(self, ctx: commands.Context, member: Member, is_leader: bool = False, *, team_name: str) -> None:
-        """Add a member to the Code Jam by specifying the team's name, and whether they should be leaders."""
+        """Add a member to the Code Jam by specifying the team's name, and whether they should be a leader."""
         callback = partial(add_flow, self.bot, team_name, ctx, member, is_leader)
         await ctx.send(
             f"Are you sure you want to add {member.mention} to {team_name}?",

--- a/bot/exts/code_jams/_flows.py
+++ b/bot/exts/code_jams/_flows.py
@@ -101,7 +101,13 @@ async def add_flow(
         )
     except ResponseCodeError as err:
         if err.response.status == 404:
-            # The user is not a participant, so the flow will proceed.
+            # The user is not a participant, so the flow will proceed,
+            # and add the user to the database if it does not exist yet.
+            try:
+                await bot.code_jam_mgmt_api.post(f"users/{member.id}", raise_for_status=True)
+            except ResponseCodeError as err:
+                if err.response.status != 400:
+                    log.error(f"Something went wrong: {err}")
             try:
                 team_to_move_in = await bot.code_jam_mgmt_api.get(
                     "teams/find",

--- a/bot/exts/code_jams/_flows.py
+++ b/bot/exts/code_jams/_flows.py
@@ -140,7 +140,8 @@ async def add_flow(
                     log.error(f"Something went wrong with processing the request! {err}")
                 return
             # Assign the roles
-            await member.add_roles(discord.utils.get(ctx.guild.roles, name=TEAM_LEADER_ROLE_NAME))
+            if is_leader:
+                await member.add_roles(discord.utils.get(ctx.guild.roles, name=TEAM_LEADER_ROLE_NAME))
             await member.add_roles(ctx.guild.get_role(Roles.code_jam_participants))
             await member.add_roles(ctx.guild.get_role(team_to_move_in['discord_role_id']))
 

--- a/bot/exts/code_jams/_flows.py
+++ b/bot/exts/code_jams/_flows.py
@@ -130,7 +130,7 @@ async def add_flow(
                 )
             except ResponseCodeError as err:
                 if err.response.status == 404:
-                    await ctx.send(":x: Team or user could not be found.")
+                    await ctx.send(":x: User could not be found.")
                 elif err.response.status == 400:
                     await ctx.send(f":x: user {member.mention} is already in {team_to_move_in['name']}")
                 else:


### PR DESCRIPTION
This PR introduces a new command and flow, which will enable the events team to add someone to the Code Jam either as a team lead or participant.

(Note: This `add_flow` is a modified version of the `move_flow`)