### PR TITLE
Fix Poetry 1.2 Support

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Python Dependencies
-        uses: HassanAbouelela/actions/setup-python@setup-python_v1.2.1
+        uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.1
         with:
           dev: true
           python_version: '3.10'
+
       # Attempt to run the bot. Setting `IN_CI` to true, so bot.run() is never called.
       # This is to catch import and cog setup errors that may appear in PRs, to avoid crash loops if merged.
       - name: Attempt bot setup
@@ -32,10 +33,9 @@ jobs:
         run: pytest --disable-warnings -q
 
       # We will not run `flake8` here, as we will use a separate flake8
-      # action. As pre-commit does not support user installs, we set
-      # PIP_USER=0 to not do a user install.
+      # action.
       - name: Run pre-commit hooks
-        run: export PIP_USER=0; SKIP=flake8 pre-commit run --all-files
+        run: SKIP=flake8 pre-commit run --all-files
 
       # Run flake8 and have it format the linting errors in the format of
       # the GitHub Workflow command to register error annotations. This

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,9 @@
-FROM --platform=linux/amd64 python:3.10-slim
+FROM --platform=linux/amd64 ghcr.io/chrislovering/python-poetry-base:3.10-slim
 
-# Set pip to have cleaner logs and no saved cache
-ENV PIP_NO_CACHE_DIR=false \
-    POETRY_VIRTUALENVS_CREATE=false
-
-# Install Poetry
-RUN pip install --upgrade poetry
-
+# Install depenencies
 WORKDIR /bot
-
-# Copy dependencies and lockfile
-COPY pyproject.toml poetry.lock /bot/
-
-# Install dependencies and lockfile, excluding development
-# dependencies,
-RUN poetry install --no-dev --no-interaction --no-ansi
+COPY pyproject.toml poetry.lock ./
+RUN poetry install --without dev
 
 # Set SHA build argument
 ARG git_sha="development"
@@ -24,4 +13,5 @@ ENV GIT_SHA=$git_sha
 COPY . .
 
 # Start the bot
+ENTRYPOINT ["poetry", "run"]
 CMD ["python", "-m", "bot"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.7"
-
 x-restart-policy: &restart_policy
   restart: unless-stopped
 


### PR DESCRIPTION
Poetry 1.2 introduced a regression which broke pip `--user` installs. These types of install were the main way we did installations in docker and CI, as they made it much more convenient to control the location, availability, and caching of packages.

Poetry's team does not recognize this as a supported use case, so major changes were required to get everything working again. Most of the changes were consolidated into chrislovering/python-poetry-base for docker, and HassanAbouelela/setup-python for CI.

This is part of a larger collection of PRs to python-discord projects