### PR TITLE
Fix wrong prefix in aoc join message

### DIFF
--- a/bot/exts/advent_of_code/_helpers.py
+++ b/bot/exts/advent_of_code/_helpers.py
@@ -14,7 +14,7 @@ from discord.ext import commands
 
 import bot
 from bot.bot import SirRobin
-from bot.constants import AdventOfCode, Channels, Colours
+from bot.constants import AdventOfCode, Channels, Client, Colours
 from bot.exts.advent_of_code import _caches
 
 log = logging.getLogger(__name__)
@@ -218,7 +218,7 @@ def _format_leaderboard(leaderboard: dict[str, dict], self_placement_name: str =
         raise commands.BadArgument(
             "Sorry, your profile does not exist in this leaderboard."
             "\n\n"
-            "To join our leaderboard, run the command `.aoc join`."
+            f"To join our leaderboard, run the command `{Client.prefix}aoc join`."
             " If you've joined recently, please wait up to 30 minutes for our leaderboard to refresh."
         )
     return "\n".join(leaderboard_lines)


### PR DESCRIPTION
## Problem
![image](https://user-images.githubusercontent.com/59766203/205258893-246de2d2-e573-4594-9ca1-461f2028f492.png)
Now, the command should be `&aoc join` because the prefix was changed.

## Changes
The command's prefix will be dynamically added in the bad argument message. This means that if the prefix ever gets changed again, the message will be adapted automatically.