### PR TITLE
Start Completionist Role Assignment

### DIFF
--- a/bot/exts/advent_of_code/_cog.py
+++ b/bot/exts/advent_of_code/_cog.py
@@ -62,7 +62,7 @@ class AdventOfCode(commands.Cog):
         self.status_task.add_done_callback(_helpers.background_task_callback)
 
         # Don't start task while event isn't running
-        # self.completionist_task.start()
+        self.completionist_task.start()
 
     @tasks.loop(minutes=10.0)
     async def completionist_task(self) -> None:


### PR DESCRIPTION
Uncomments the starting of the completionist role task. A better approach for future years will be taken after this event ends.