### PR TITLE
Extend AoC commands to Feb

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: check-yaml
         args: [--unsafe]
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)

--- a/bot/exts/advent_of_code/_cog.py
+++ b/bot/exts/advent_of_code/_cog.py
@@ -241,7 +241,7 @@ class AdventOfCode(commands.Cog):
         ]
         await interaction.response.send_message("\n".join(info_str), ephemeral=True)
 
-    @in_month(Month.NOVEMBER, Month.DECEMBER, Month.JANUARY)
+    @in_month(Month.NOVEMBER, Month.DECEMBER, Month.JANUARY, Month.FEBRUARY)
     @adventofcode_group.command(
         name="link",
         aliases=("connect",),
@@ -293,7 +293,7 @@ class AdventOfCode(commands.Cog):
                     " Please re-run the command with one specified."
                 )
 
-    @in_month(Month.NOVEMBER, Month.DECEMBER, Month.JANUARY)
+    @in_month(Month.NOVEMBER, Month.DECEMBER, Month.JANUARY, Month.FEBRUARY)
     @adventofcode_group.command(
         name="unlink",
         aliases=("disconnect",),
@@ -314,7 +314,7 @@ class AdventOfCode(commands.Cog):
             log.info(f"Attempted to unlink {ctx.author} ({ctx.author.id}), but no link was found.")
             await ctx.reply("You don't have an Advent of Code account linked.")
 
-    @in_month(Month.DECEMBER, Month.JANUARY)
+    @in_month(Month.DECEMBER, Month.JANUARY, Month.FEBRUARY)
     @adventofcode_group.command(
         name="dayandstar",
         aliases=("daynstar", "daystar"),
@@ -352,7 +352,7 @@ class AdventOfCode(commands.Cog):
         await view.wait()
         await message.edit(view=None)
 
-    @in_month(Month.DECEMBER, Month.JANUARY)
+    @in_month(Month.DECEMBER, Month.JANUARY, Month.FEBRUARY)
     @adventofcode_group.command(
         name="leaderboard",
         aliases=("board", "lb"),
@@ -397,7 +397,7 @@ class AdventOfCode(commands.Cog):
         await ctx.send(content=f"{header}\n\n{table}", embed=info_embed)
         return
 
-    @in_month(Month.DECEMBER, Month.JANUARY)
+    @in_month(Month.DECEMBER, Month.JANUARY, Month.FEBRUARY)
     @adventofcode_group.command(
         name="global",
         aliases=("globalboard", "gb"),


### PR DESCRIPTION
We keep Advent of Code around until February (plus a week or two into February) for the AoC Completionist role. I'd like have the core commands available during the 1-2 weeks into February we keep it around for people to fix and account linking or if they finish AoC at the very end of January.