### PR TITLE
Bump python version to 3.11

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Python Dependencies
         uses: HassanAbouelela/actions/setup-python@setup-python_v1.4.0
         with:
-          python_version: '3.10'
+          python_version: '3.11'
           install_args: "--only main --only lint --only test"
 
       # Attempt to run the bot. Setting `IN_CI` to true, so bot.run() is never called.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ghcr.io/chrislovering/python-poetry-base:3.10-slim
+FROM --platform=linux/amd64 ghcr.io/chrislovering/python-poetry-base:3.11-slim
 
 # Install depenencies
 WORKDIR /bot

--- a/bot/converters.py
+++ b/bot/converters.py
@@ -1,10 +1,8 @@
-from typing import Union
-
 from discord.ext import commands
 from discord.ext.commands import BadArgument, Context, Converter
 from discord.utils import escape_markdown
 
-SourceType = Union[commands.HelpCommand, commands.Command, commands.Cog, str, commands.ExtensionNotLoaded]
+SourceType = commands.HelpCommand | commands.Command | commands.Cog | str | commands.ExtensionNotLoaded
 
 
 class SourceConverter(Converter):

--- a/bot/exts/advent_of_code/_cog.py
+++ b/bot/exts/advent_of_code/_cog.py
@@ -2,7 +2,6 @@ import json
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
 
 import arrow
 import discord
@@ -324,7 +323,7 @@ class AdventOfCode(commands.Cog):
     async def aoc_day_and_star_leaderboard(
             self,
             ctx: commands.Context,
-            maximum_scorers_day_and_star: Optional[int] = 10
+            maximum_scorers_day_and_star: int = 10
     ) -> None:
         """Have the bot send a View that will let you filter the leaderboard by day and star."""
         if maximum_scorers_day_and_star > AocConfig.max_day_and_star_results or maximum_scorers_day_and_star <= 0:
@@ -359,7 +358,7 @@ class AdventOfCode(commands.Cog):
         brief="Get a snapshot of the PyDis private AoC leaderboard",
     )
     @whitelist_override(channels=AOC_WHITELIST_RESTRICTED)
-    async def aoc_leaderboard(self, ctx: commands.Context, *, aoc_name: Optional[str] = None) -> None:
+    async def aoc_leaderboard(self, ctx: commands.Context, *, aoc_name: str | None = None) -> None:
         """
         Get the current top scorers of the Python Discord Leaderboard.
 

--- a/bot/exts/advent_of_code/_helpers.py
+++ b/bot/exts/advent_of_code/_helpers.py
@@ -5,7 +5,7 @@ import json
 import logging
 import math
 import operator
-from typing import Any, Optional
+from typing import Any
 
 import aiohttp
 import arrow
@@ -395,7 +395,7 @@ def get_summary_embed(leaderboard: dict) -> discord.Embed:
     return aoc_embed
 
 
-async def get_public_join_code(author: discord.Member) -> Optional[str]:
+async def get_public_join_code(author: discord.Member) -> str | None:
     """
     Get the join code for one of the non-staff leaderboards.
 

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -1,5 +1,4 @@
 import csv
-import typing as t
 from collections import defaultdict
 from functools import partial
 from typing import Optional
@@ -39,7 +38,7 @@ class CodeJams(commands.Cog):
 
     @codejam.command()
     @commands.has_any_role(Roles.admins, Roles.events_lead)
-    async def create(self, ctx: commands.Context, csv_file: t.Optional[str] = None) -> None:
+    async def create(self, ctx: commands.Context, csv_file: str | None = None) -> None:
         """
         Create code-jam teams from a CSV file or a link to one, specifying the team names, leaders and members.
 
@@ -238,7 +237,7 @@ class CodeJams(commands.Cog):
             return roles
 
     @staticmethod
-    def team_channel(guild: Guild, criterion: t.Union[str, Member]) -> t.Optional[discord.TextChannel]:
+    def team_channel(guild: Guild, criterion: str | Member) -> discord.TextChannel | None:
         """Get a team channel through either a participant or the team name."""
         for category in CodeJams.jam_categories(guild):
             for channel in category.channels:

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -1,7 +1,6 @@
 import csv
 from collections import defaultdict
 from functools import partial
-from typing import Optional
 
 import discord
 from discord import Colour, Embed, Guild, Member
@@ -181,7 +180,7 @@ class CodeJams(commands.Cog):
             self,
             ctx: commands.Context,
             member: Member,
-            is_leader: Optional[bool] = False,
+            is_leader: bool = False,
             *,
             team_name: str
     ) -> None:
@@ -205,14 +204,14 @@ class CodeJams(commands.Cog):
     @codejam.command()
     @commands.has_any_role(Roles.admins, Roles.events_lead, Roles.code_jam_event_team, Roles.code_jam_participants)
     @in_code_jam_category(_creation_utils.CATEGORY_NAME)
-    async def pin(self, ctx: commands.Context, message: Optional[discord.Message] = None) -> None:
+    async def pin(self, ctx: commands.Context, message: discord.Message | None = None) -> None:
         """Lets Code Jam Participants to pin messages in their team channels."""
         await pin_flow(ctx, PIN_ALLOWED_ROLES, self.bot.code_jam_mgmt_api, message)
 
     @codejam.command()
     @commands.has_any_role(Roles.admins, Roles.events_lead, Roles.code_jam_event_team, Roles.code_jam_participants)
     @in_code_jam_category(_creation_utils.CATEGORY_NAME)
-    async def unpin(self, ctx: commands.Context, message: Optional[discord.Message] = None) -> None:
+    async def unpin(self, ctx: commands.Context, message: discord.Message | None = None) -> None:
         """Lets Code Jam Participants to unpin messages in their team channels."""
         await pin_flow(ctx, PIN_ALLOWED_ROLES, self.bot.code_jam_mgmt_api, message, True)
 
@@ -222,7 +221,7 @@ class CodeJams(commands.Cog):
         return [category for category in guild.categories if category.name == _creation_utils.CATEGORY_NAME]
 
     @staticmethod
-    async def jam_roles(guild: Guild, mgmt_client: APIClient) -> Optional[list[discord.Role]]:
+    async def jam_roles(guild: Guild, mgmt_client: APIClient) -> list[discord.Role] | None:
         """Get all the code jam team roles."""
         try:
             roles_raw = await mgmt_client.get("teams", raise_for_status=True, params={"current_jam": "true"})

--- a/bot/exts/code_jams/_creation_utils.py
+++ b/bot/exts/code_jams/_creation_utils.py
@@ -1,5 +1,3 @@
-import typing as t
-
 import discord
 from discord.ext import commands
 from pydis_core.utils.logging import get_logger
@@ -56,7 +54,7 @@ async def _get_category(guild: discord.Guild) -> discord.CategoryChannel:
 def _get_overwrites(
         guild: discord.Guild,
         team_role: discord.Role
-) -> dict[t.Union[discord.Member, discord.Role], discord.PermissionOverwrite]:
+) -> dict[discord.Member | discord.Role, discord.PermissionOverwrite]:
     """Get code jam team channels permission overwrites."""
     return {
         guild.default_role: discord.PermissionOverwrite(read_messages=False),

--- a/bot/exts/code_jams/_flows.py
+++ b/bot/exts/code_jams/_flows.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Optional
 from urllib.parse import quote as quote_url
 
 import discord
@@ -295,7 +294,7 @@ async def pin_flow(
         ctx: commands.Context,
         roles: tuple[int, ...],
         mgmt_api: APIClient,
-        message: Optional[discord.Message] = None,
+        message: discord.Message | None = None,
         unpin: bool = False
 ) -> None:
     """

--- a/bot/exts/code_jams/_views.py
+++ b/bot/exts/code_jams/_views.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable
 
 import discord
 from pydis_core.site_api import APIClient, ResponseCodeError
@@ -17,7 +17,7 @@ async def interaction_fetch_user_data(
         endpoint: str,
         mgmt_client: APIClient,
         interaction: discord.Interaction
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     """A helper function for fetching and handling user related data in an interaction."""
     try:
         user = await mgmt_client.get(endpoint, raise_for_status=True)

--- a/bot/exts/miscellaneous.py
+++ b/bot/exts/miscellaneous.py
@@ -1,5 +1,4 @@
 import difflib
-from typing import Union
 
 from discord import Colour, Embed
 from discord.ext import commands
@@ -40,7 +39,7 @@ class Miscellaneous(commands.Cog):
         self.bot = bot
 
     @commands.command()
-    async def zen(self, ctx: commands.Context, *, search_value: Union[int, str, None] = None) -> None:
+    async def zen(self, ctx: commands.Context, *, search_value: int | str | None = None) -> None:
         """Display the Zen of Python in an embed."""
         embed = Embed(
             colour=Colour.og_blurple(),

--- a/bot/exts/pep.py
+++ b/bot/exts/pep.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from email.parser import HeaderParser
 from io import StringIO
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
 from discord import Colour, Embed
 from discord.ext.commands import Cog, Context, command
@@ -70,7 +70,7 @@ class PythonEnhancementProposals(Cog):
 
         return pep_embed
 
-    async def validate_pep_number(self, pep_nr: int) -> Optional[Embed]:
+    async def validate_pep_number(self, pep_nr: int) -> Embed | None:
         """Validate is PEP number valid. When it isn't, return error embed, otherwise None."""
         if (
             pep_nr not in self.peps

--- a/bot/exts/source.py
+++ b/bot/exts/source.py
@@ -1,6 +1,6 @@
 import inspect
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Tuple
 
 from discord import Embed
 from discord.ext import commands
@@ -38,7 +38,7 @@ class BotSource(commands.Cog):
         embed = await self.build_embed(source_item)
         await ctx.send(embed=embed)
 
-    def get_source_link(self, source_item: SourceType) -> Tuple[str, str, Optional[int]]:
+    def get_source_link(self, source_item: SourceType) -> Tuple[str, str, int | None]:
         """
         Build GitHub link of source item, return this link, file location and first line number.
 
@@ -72,7 +72,7 @@ class BotSource(commands.Cog):
 
         return url, file_location, first_line_no or None
 
-    async def build_embed(self, source_object: SourceType) -> Optional[Embed]:
+    async def build_embed(self, source_object: SourceType) -> Embed | None:
         """Build embed based on source object."""
         url, location, first_line = self.get_source_link(source_object)
 

--- a/bot/exts/summer_aoc.py
+++ b/bot/exts/summer_aoc.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from datetime import timedelta
-from typing import Literal, Optional
+from typing import Literal
 
 import arrow
 import discord
@@ -60,15 +60,15 @@ class SummerAoC(commands.Cog):
 
     def __init__(self, bot: SirRobin):
         self.bot = bot
-        self.wait_task: Optional[asyncio.Task] = None
-        self.loop_task: Optional[tasks.Loop] = None
+        self.wait_task: asyncio.Task | None = None
+        self.loop_task: tasks.Loop | None = None
 
         self.is_running = False
-        self.year: Optional[int] = None
-        self.current_day: Optional[int] = None
-        self.day_interval: Optional[int] = None
+        self.year: int | None = None
+        self.current_day: int | None = None
+        self.day_interval: int | None = None
         self.post_time = 0
-        self.first_post_date: Optional[arrow.Arrow] = None
+        self.first_post_date: arrow.Arrow | None = None
 
         self.bot.loop.create_task(self.load_event_state())
 
@@ -76,7 +76,7 @@ class SummerAoC(commands.Cog):
         """Check whether all the necessary settings are configured to run the event."""
         return None not in (self.year, self.current_day, self.day_interval, self.post_time)
 
-    def next_post_time(self) -> Optional[arrow.Arrow]:
+    def next_post_time(self) -> arrow.Arrow | None:
         """Calculate the datetime of the next scheduled post or None if there isn't one."""
         if not self.is_running:
             return None
@@ -160,7 +160,7 @@ class SummerAoC(commands.Cog):
         await self.start_event()
 
     @summer_aoc_group.command(name="force")
-    async def force_day(self, ctx: commands.Context, day: int, now: Optional[Literal["now"]] = None) -> None:
+    async def force_day(self, ctx: commands.Context, day: int, now: Literal["now"] | None = None) -> None:
         """
         Force-set the current day of the event. Use `now` to post the puzzle immediately.
         Can be used without starting the event first as long as the necessary settings are already stored.

--- a/bot/services.py
+++ b/bot/services.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from aiohttp import ClientConnectorError
 
 import bot
@@ -11,7 +9,7 @@ FAILED_REQUEST_ATTEMPTS = 3
 PASTE_URL = "https://paste.pythondiscord.com"
 
 
-async def send_to_paste_service(contents: str, *, extension: str = "") -> Optional[str]:
+async def send_to_paste_service(contents: str, *, extension: str = "") -> str | None:
     """
     Upload `contents` to the paste service.
 

--- a/bot/utils/__init__.py
+++ b/bot/utils/__init__.py
@@ -4,7 +4,6 @@ import re
 import string
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Optional
 
 import discord
 from discord.ext.commands import BadArgument, Context
@@ -38,7 +37,7 @@ async def disambiguate(
     timeout: float = 30,
     entries_per_page: int = 20,
     empty: bool = False,
-    embed: Optional[discord.Embed] = None
+    embed: discord.Embed | None = None
 ) -> str:
     """
     Has the user choose between multiple entries in case one could not be chosen automatically.

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -1,5 +1,5 @@
 from collections.abc import Container
-from typing import Callable, NoReturn, Optional, Union
+from typing import Callable, NoReturn, Optional
 
 from discord.ext import commands
 from discord.ext.commands import CheckFailure, Context
@@ -12,8 +12,8 @@ log = get_logger(__name__)
 
 
 def in_code_jam_category(code_jam_category_name: str) -> Callable:
-    """Raises `CodeJamCategoryCheckFailure` when the command is invoked outside of the Code Jam categories."""
-    async def predicate(ctx: commands.Context) -> Union[bool, NoReturn]:
+    """Raises `CodeJamCategoryCheckFailure` when the command is invoked outside the Code Jam categories."""
+    async def predicate(ctx: commands.Context) -> bool | NoReturn:
         if not ctx.guild:
             return False
         if not ctx.message.channel.category:
@@ -57,7 +57,7 @@ def in_whitelist_check(
 
     - `channels`: a container with channel ids for whitelisted channels
     - `categories`: a container with category ids for whitelisted categories
-    - `roles`: a container with with role ids for whitelisted roles
+    - `roles`: a container with role ids for whitelisted roles
 
     If the command was invoked in a context that was not whitelisted, the member is either
     redirected to the `redirect` channel that was passed (default: #bot-commands) or simply

--- a/bot/utils/checks.py
+++ b/bot/utils/checks.py
@@ -1,5 +1,5 @@
 from collections.abc import Container
-from typing import Callable, NoReturn, Optional
+from typing import Callable, NoReturn
 
 from discord.ext import commands
 from discord.ext.commands import CheckFailure, Context
@@ -29,7 +29,7 @@ def in_code_jam_category(code_jam_category_name: str) -> Callable:
 class InWhitelistCheckFailure(CheckFailure):
     """Raised when the `in_whitelist` check fails."""
 
-    def __init__(self, redirect_channel: Optional[int]):
+    def __init__(self, redirect_channel: int | None):
         self.redirect_channel = redirect_channel
 
         if redirect_channel:
@@ -47,7 +47,7 @@ def in_whitelist_check(
     channels: Container[int] = (),
     categories: Container[int] = (),
     roles: Container[int] = (),
-    redirect: Optional[int] = constants.Channels.sir_lancebot_playground,
+    redirect: int | None = constants.Channels.sir_lancebot_playground,
     fail_silently: bool = False,
 ) -> bool:
     """

--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -5,7 +5,7 @@ import random
 from asyncio import Lock
 from collections.abc import Container
 from functools import wraps
-from typing import Callable, Optional, Union
+from typing import Callable, Optional
 from weakref import WeakValueDictionary
 
 from discord import Colour, Embed
@@ -33,7 +33,7 @@ class InMonthCheckFailure(CheckFailure):
     pass
 
 
-def seasonal_task(*allowed_months: Month, sleep_time: Union[float, int] = ONE_DAY) -> Callable:
+def seasonal_task(*allowed_months: Month, sleep_time: float | int = ONE_DAY) -> Callable:
     """
     Perform the decorated method periodically in `allowed_months`.
 

--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -5,7 +5,7 @@ import random
 from asyncio import Lock
 from collections.abc import Container
 from functools import wraps
-from typing import Callable, Optional
+from typing import Callable
 from weakref import WeakValueDictionary
 
 from discord import Colour, Embed
@@ -201,7 +201,7 @@ def whitelist_check(**default_kwargs: Container[int]) -> Callable[[Context], boo
 
         # Determine which command's overrides we will use. Group commands will
         # inherit from their parents if they don't define their own overrides
-        overridden_command: Optional[commands.Command] = None
+        overridden_command: commands.Command | None = None
         for command in [ctx.command, *ctx.command.parents]:
             if hasattr(command.callback, "override"):
                 overridden_command = command
@@ -319,7 +319,7 @@ def whitelist_override(bypass_defaults: bool = False, allow_dm: bool = False, **
     return inner
 
 
-def locked() -> Optional[Callable]:
+def locked() -> Callable | None:
     """
     Allows the user to only run one instance of the decorated command at a time.
 
@@ -327,11 +327,11 @@ def locked() -> Optional[Callable]:
 
     This decorator has to go before (below) the `command` decorator.
     """
-    def wrap(func: Callable) -> Optional[Callable]:
+    def wrap(func: Callable) -> Callable | None:
         func.__locks = WeakValueDictionary()
 
         @wraps(func)
-        async def inner(self: Callable, ctx: Context, *args, **kwargs) -> Optional[Callable]:
+        async def inner(self: Callable, ctx: Context, *args, **kwargs) -> Callable | None:
             lock = func.__locks.setdefault(ctx.author.id, Lock())
             if lock.locked():
                 embed = Embed()

--- a/bot/utils/members.py
+++ b/bot/utils/members.py
@@ -6,7 +6,7 @@ import discord
 log = logging.getLogger(__name__)
 
 
-async def get_or_fetch_member(guild: discord.Guild, member_id: int) -> t.Optional[discord.Member]:
+async def get_or_fetch_member(guild: discord.Guild, member_id: int) -> discord.Member | None:
     """
     Attempt to get a member from cache; on failure fetch from the API.
 

--- a/bot/utils/pagination.py
+++ b/bot/utils/pagination.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from collections.abc import Iterable
-from typing import Optional
 
 from discord import Embed, Member, Reaction
 from discord.abc import User
@@ -32,7 +31,7 @@ class LinePaginator(Paginator):
             prefix: str = '```',
             suffix: str = '```',
             max_size: int = 2000,
-            max_lines: Optional[int] = None,
+            max_lines: int | None = None,
             linesep: str = "\n"
     ):
         """
@@ -88,7 +87,7 @@ class LinePaginator(Paginator):
 
     @classmethod
     async def paginate(cls, lines: Iterable[str], ctx: Context, embed: Embed,
-                       prefix: str = "", suffix: str = "", max_lines: Optional[int] = None,
+                       prefix: str = "", suffix: str = "", max_lines: int | None = None,
                        max_size: int = 500, empty: bool = True, restrict_to_user: User = None,
                        timeout: int = 300, footer_text: str = None, url: str = None,
                        exception_on_empty_embed: bool = False) -> None:

--- a/bot/utils/services.py
+++ b/bot/utils/services.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from aiohttp import ClientConnectorError
 from pydis_core.utils.logging import get_logger
 
@@ -11,7 +9,7 @@ FAILED_REQUEST_ATTEMPTS = 3
 PASTE_SERVICE = "https://paste.pythondiscord.com/{key}"
 
 
-async def send_to_paste_service(contents: str, *, extension: str = "") -> Optional[str]:
+async def send_to_paste_service(contents: str, *, extension: str = "") -> str | None:
     """
     Upload `contents` to the paste service.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Python Discord <info@pythondiscord.com>"]
 
 [tool.poetry.dependencies]
-python = "3.10.*"
+python = "3.11.*"
 
 pydis-core = { version = "9.4.1", extras = ["async-rediscache"]}
 arrow = "1.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ pre-commit = "2.20.0"
 start = "python -m bot"
 lint = "pre-commit run --all-files"
 precommit = "pre-commit install"
+test = "python -m unittest discover"
 
 [build-system]
 requires = ["poetry-core>=1.2.0"]

--- a/tests/_autospec.py
+++ b/tests/_autospec.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import pkgutil
 import unittest.mock
 from typing import Callable
 
@@ -51,7 +52,7 @@ def autospec(target, *attributes: str, pass_mocks: bool = True, **patch_kwargs) 
     # Import the target if it's a string.
     # This is to support both object and string targets like patch.multiple.
     if type(target) is str:
-        target = unittest.mock._importer(target)
+        target = pkgutil.resolve_name(target)
 
     def decorator(func):
         for attribute in attributes:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,7 @@ import itertools
 import logging
 import unittest.mock
 from asyncio import AbstractEventLoop
-from typing import Iterable, Optional
+from typing import Iterable
 
 import discord
 from aiohttp import ClientSession
@@ -170,7 +170,7 @@ class MockGuild(CustomMockMixin, unittest.mock.Mock, HashableMixin):
     """
     spec_set = guild_instance
 
-    def __init__(self, roles: Optional[Iterable[MockRole]] = None, **kwargs) -> None:
+    def __init__(self, roles: Iterable[MockRole] | None = None, **kwargs) -> None:
         default_kwargs = {'id': next(self.discord_id), 'members': [], "chunked": True}
         super().__init__(**collections.ChainMap(kwargs, default_kwargs))
 
@@ -236,7 +236,7 @@ class MockMember(CustomMockMixin, unittest.mock.Mock, ColourMixin, HashableMixin
     """
     spec_set = member_instance
 
-    def __init__(self, roles: Optional[Iterable[MockRole]] = None, **kwargs) -> None:
+    def __init__(self, roles: Iterable[MockRole] | None = None, **kwargs) -> None:
         default_kwargs = {'name': 'member', 'id': next(self.discord_id), 'bot': False, "pending": False}
         super().__init__(**collections.ChainMap(kwargs, default_kwargs))
 


### PR DESCRIPTION
This bumps sir-robin's python version to 3.11.

By the same occasion, this updates all references of `typing.Optional` and `typing.Union` to use the `|` gate.