### PR TITLE
Code Jam Permissions Update and a little bit extra

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -141,6 +141,9 @@ class Roles(NamedTuple):
     code_jam_participants = int(environ.get("CODE_JAM_PARTICIPANTS", 991678713093705781))
     helpers = int(environ.get("ROLE_HELPERS", 267630620367257601))
     aoc_completionist = int(environ.get("AOC_COMPLETIONIST_ROLE_ID", 916691790181056532))
+    bot_sir_robin = int(environ.get("BOT_SIR_ROBIN", 945317561472544838))
+    bot_sir_lancebot = int(environ.get("BOT_SIR_LANCEBOT", 807437823262982144))
+    bot_python = int(environ.get("BOT_PYTHON", 270988689419665409))
 
 
 class RedisConfig(NamedTuple):

--- a/bot/exts/code_jams/_creation_utils.py
+++ b/bot/exts/code_jams/_creation_utils.py
@@ -17,7 +17,10 @@ async def _create_category(guild: discord.Guild) -> discord.CategoryChannel:
 
     category_overwrites = {
         guild.default_role: discord.PermissionOverwrite(read_messages=False),
-        guild.me: discord.PermissionOverwrite(read_messages=True)
+        guild.me: discord.PermissionOverwrite(read_messages=True),
+        guild.get_role(Roles.bot_sir_lancebot): discord.PermissionOverwrite(read_messages=True),
+        guild.get_role(Roles.bot_python): discord.PermissionOverwrite(read_messages=True),
+        guild.get_role(Roles.events_lead): discord.PermissionOverwrite(manage_channels=True),
     }
     category = await guild.create_category_channel(
         CATEGORY_NAME,
@@ -58,8 +61,12 @@ def _get_overwrites(
     """Get code jam team channels permission overwrites."""
     return {
         guild.default_role: discord.PermissionOverwrite(read_messages=False),
+        guild.get_role(Roles.events_lead): discord.PermissionOverwrite(manage_channels=True),
         guild.get_role(Roles.code_jam_event_team): discord.PermissionOverwrite(read_messages=True),
-        team_role: discord.PermissionOverwrite(read_messages=True)
+        team_role: discord.PermissionOverwrite(read_messages=True),
+        guild.get_role(Roles.bot_sir_robin): discord.PermissionOverwrite(read_messages=True, send_messages=True),
+        guild.get_role(Roles.bot_sir_lancebot): discord.PermissionOverwrite(read_messages=True, send_messages=True),
+        guild.get_role(Roles.bot_python): discord.PermissionOverwrite(read_messages=True, send_messages=True),
     }
 
 


### PR DESCRIPTION
This corrects some permissions issues from last year:
- Adds Sir Robin to individual team channels
- Give the Event Lead roles manage_channels permission for the category
- Adds Sir Lancebot and Python to team channels and the category overall, just to be sure

Why do we have to override permissions on the individual channels when it's being added to the category is a reasonable question you might ask when looking at this PR. The answer lies in the hell that is the Discord channel permission system. When creating a channel from a category, if you override the permissions *during* creation, it will not inherit the permissions from the category. We override the permissions on creation to add the individual team roles. So therefore we need to duplicate some efforts to make sure we cover our bases.

Also this change will ping teams in their team channels when we announce. This is a QoL change requested from last year that I went ahead and implemented since I had to edit the `_views.py` file anyway.

Also d.py changed the ordering of their arguments for the UI `on_error` function, so I had to correct that as well.