### PR TITLE
Remove `!subscribe` and references.

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -96,6 +96,7 @@ class _Channels(EnvConfig, env_prefix="CHANNEL_"):
     off_topic_2: int = 463035268514185226
     voice_chat_0: int = 412357430186344448
     voice_chat_1: int = 799647045886541885
+    roles: int = 851270062434156586
 
 
 Channels = _Channels()

--- a/bot/exts/advent_of_code/_cog.py
+++ b/bot/exts/advent_of_code/_cog.py
@@ -24,7 +24,6 @@ from bot.exts.advent_of_code import _helpers
 from bot.exts.advent_of_code.views.dayandstarview import AoCDropdownView
 from bot.utils import members
 from bot.utils.decorators import InChannelCheckFailure, in_month, whitelist_override, with_role
-from bot.utils.exceptions import MovedCommandError
 
 log = logging.getLogger(__name__)
 
@@ -148,21 +147,6 @@ class AdventOfCode(commands.Cog):
 
         await self.completionist_block_list.set(member.id, "sentinel")
         await ctx.send(f":+1: Blocked {member.mention} from getting the AoC completionist role.")
-
-    @commands.guild_only()
-    @adventofcode_group.command(
-        name="subscribe",
-        aliases=("sub", "notifications", "notify", "notifs", "unsubscribe", "unsub"),
-        help=f"NOTE: This command has been moved to {Bot.prefix}subscribe",
-    )
-    @whitelist_override(channels=AOC_WHITELIST)
-    async def aoc_subscribe(self, ctx: commands.Context) -> None:
-        """
-        Deprecated role command.
-
-        This command has been moved to bot, and will be removed in the future.
-        """
-        raise MovedCommandError(f"{Bot.prefix}subscribe")
 
     @adventofcode_group.command(name="countdown", aliases=("count", "c"), brief="Return time left until next day")
     @whitelist_override(channels=AOC_WHITELIST)

--- a/bot/exts/summer_aoc.py
+++ b/bot/exts/summer_aoc.py
@@ -44,7 +44,7 @@ If you have questions or suggestions about the event itself, head over to <#{dis
 
 NEXT_PUZZLE_TEXT = """
 The next puzzle will be posted <t:{timestamp}:R>.
-To receive notifications when new puzzles are released, run `!subscribe` in <#{bot_commands}> and assign yourself \
+To recieve notifications when new puzzles are released, head over to <#{roles}> and assign yourself \
 the Revival of Code role.
 """
 
@@ -330,7 +330,7 @@ class SummerAoC(commands.Cog):
         else:
             next_puzzle_text = NEXT_PUZZLE_TEXT.format(
                 timestamp=int(self.next_post_time().timestamp()),
-                bot_commands=Channels.bot_commands,
+                roles=Channels.roles
             )
         post_text = POST_TEXT.format(
             public_name=PUBLIC_NAME,

--- a/bot/utils/exceptions.py
+++ b/bot/utils/exceptions.py
@@ -8,11 +8,3 @@ class JamCategoryNameConflictError(Exception):
 
 class CodeJamCategoryCheckFailure(CheckFailure):
     """Raised when the specified command was run outside the Code Jam categories."""
-
-
-
-class MovedCommandError(Exception):
-    """Raised when a command has moved locations."""
-
-    def __init__(self, new_command_name: str):
-        self.new_command_name = new_command_name


### PR DESCRIPTION
Closes #99

Removes the `!subscribe`  command any references to it, since we have a new way of doing roles. Should be ready to reveiew and merge, grep seems to be returning no more results for `!subscribe`, or `subscribe`.
