### PR TITLE
Create slash command for `&aoc countdown`

### DIFF
--- a/bot/exts/advent_of_code/_cog.py
+++ b/bot/exts/advent_of_code/_cog.py
@@ -182,6 +182,25 @@ class AdventOfCode(commands.Cog):
             f"The next event will start <t:{next_aoc_timestamp}:R>."
         )
 
+    @aoc_slash_group.command(name="countdown", description="Return time left until next day")
+    @whitelist_override(channels=AOC_WHITELIST)
+    async def aoc_countdown_slash(self, interaction: discord.Interaction) -> None:
+        """Return time left until next day."""
+        if _helpers.is_in_advent():
+            tomorrow, _ = _helpers.time_left_to_est_midnight()
+            next_day_timestamp = int(tomorrow.timestamp())
+
+            await interaction.response.send_message(f"Day {tomorrow.day} starts <t:{next_day_timestamp}:R>.")
+            return
+
+        next_aoc, _ = _helpers.time_left_to_next_aoc()
+        next_aoc_timestamp = int(next_aoc.timestamp())
+
+        await interaction.response.send_message(
+            "The Advent of Code event is not currently running. "
+            f"The next event will start <t:{next_aoc_timestamp}:R>."
+        )
+
     @adventofcode_group.command(name="about", aliases=("ab", "info"), brief="Learn about Advent of Code")
     @whitelist_override(channels=AOC_WHITELIST)
     async def about_aoc(self, ctx: commands.Context) -> None:

--- a/bot/exts/advent_of_code/_cog.py
+++ b/bot/exts/advent_of_code/_cog.py
@@ -1,9 +1,8 @@
 import json
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 
-import arrow
 import discord
 from async_rediscache import RedisCache
 from discord import app_commands
@@ -175,14 +174,8 @@ class AdventOfCode(commands.Cog):
             await ctx.send(f"Day {tomorrow.day} starts <t:{next_day_timestamp}:R>.")
             return
 
-        datetime_now = arrow.now(_helpers.EST)
-        # Calculate the delta to this & next year's December 1st to see which one is closest and not in the past
-        this_year = arrow.get(datetime(datetime_now.year, 12, 1, tzinfo=UTC), _helpers.EST)
-        next_year = arrow.get(datetime(datetime_now.year + 1, 12, 1, tzinfo=UTC), _helpers.EST)
-        deltas = (dec_first - datetime_now for dec_first in (this_year, next_year))
-        delta = min(delta for delta in deltas if delta >= timedelta())  # timedelta() gives 0 duration delta
-
-        next_aoc_timestamp = int((datetime_now + delta).timestamp())
+        next_aoc, _ = _helpers.time_left_to_next_aoc()
+        next_aoc_timestamp = int(next_aoc.timestamp())
 
         await ctx.send(
             "The Advent of Code event is not currently running. "

--- a/bot/exts/advent_of_code/_helpers.py
+++ b/bot/exts/advent_of_code/_helpers.py
@@ -460,6 +460,20 @@ def is_in_advent() -> bool:
     return arrow.now(EST).day in range(1, 25) and arrow.now(EST).month == 12
 
 
+def time_left_to_next_aoc() -> tuple[datetime.datetime, datetime.timedelta]:
+    """
+    Calculate the amount of time left until the next AoC.
+
+    This will be either this year or next year's December 1, whichever one is
+    closer and not in the past.
+    """
+    datetime_now = arrow.now(EST)
+    this_year = arrow.get(datetime.datetime(datetime_now.year, 12, 1, tzinfo=datetime.UTC), EST)
+    next_year = arrow.get(datetime.datetime(datetime_now.year + 1, 12, 1, tzinfo=datetime.UTC), EST)
+    dec_first = this_year if this_year > datetime_now else next_year
+    return dec_first, dec_first - datetime_now
+
+
 def time_left_to_est_midnight() -> tuple[datetime.datetime, datetime.timedelta]:
     """Calculate the amount of time left until midnight EST/UTC-5."""
     # Change all time properties back to 00:00


### PR DESCRIPTION
Part of #97 

![image](https://github.com/python-discord/sir-robin/assets/84215197/a14190ca-959c-4707-ba25-523b15ae7b7c)

I feel like duplicating the code isn't the best way to go about this, but I couldn't really think of anything else. Any suggestions to avoid it are welcome.