### PR TITLE
Update default role id for AoC Completionist

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -177,7 +177,7 @@ class _Roles(EnvConfig, env_prefix="ROLE_"):
     summer_aoc: int = 988801794668908655
     code_jam_participants: int = 991678713093705781
     helpers: int = 267630620367257601
-    aoc_completionist: int = 916691790181056532
+    aoc_completionist: int = 1191547731873894440
     bots: int = 277546923144249364
 
 


### PR DESCRIPTION
I have all of January to create a proper start/stop command ... what could possibly go wrong.