### PR TITLE
Command to toggle issuing AoC completionist

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -140,6 +140,7 @@ class _Bot(EnvConfig, env_prefix="BOT_"):
     prefix: str = "&"
     token: str
     debug: bool = True
+    trace_logging: bool = False
     in_ci: bool = False
     github_bot_repo: str = "https://github.com/python-discord/sir-robin"
     # Override seasonal locks: 1 (January) to 12 (December)

--- a/bot/exts/advent_of_code/_caches.py
+++ b/bot/exts/advent_of_code/_caches.py
@@ -1,4 +1,10 @@
+from enum import Enum
+
 import async_rediscache
+
+
+class AoCSettingOption(Enum):
+    COMPLETIONIST_ENABLED = "completionist_enabled"
 
 # How many people are in each leaderboard
 # RedisCache[leaderboard_id, int]
@@ -19,3 +25,7 @@ account_links = async_rediscache.RedisCache(namespace="AOC_account_links")
 # Member IDs that are blocked from receiving the AoC completionist role
 # RedisCache[member_id, sentinel_value]
 completionist_block_list = async_rediscache.RedisCache(namespace="AOC_completionist_block_list")
+
+# AoC settings cache
+# RedisCache[AoCSettingOption, bool]
+aoc_settings = async_rediscache.RedisCache(namespace="AOC_settings")

--- a/bot/exts/advent_of_code/_caches.py
+++ b/bot/exts/advent_of_code/_caches.py
@@ -1,5 +1,21 @@
 import async_rediscache
 
+# How many people are in each leaderboard
+# RedisCache[leaderboard_id, int]
 leaderboard_counts = async_rediscache.RedisCache(namespace="AOC_leaderboard_counts")
+
+# Cache of data from the AoC website
+# See _helpers.fetch_leaderboard for the structure of this RedisCache
 leaderboard_cache = async_rediscache.RedisCache(namespace="AOC_leaderboard_cache")
+
+# Which leaderboard each user is in
+# RedisCache[member_id, leaderboard_id]
 assigned_leaderboard = async_rediscache.RedisCache(namespace="AOC_assigned_leaderboard")
+
+# Linking Discord IDs to Advent of Code usernames
+# RedisCache[member_id, aoc_username_string]
+account_links = async_rediscache.RedisCache(namespace="AOC_account_links")
+
+# Member IDs that are blocked from receiving the AoC completionist role
+# RedisCache[member_id, sentinel_value]
+completionist_block_list = async_rediscache.RedisCache(namespace="AOC_completionist_block_list")

--- a/bot/exts/advent_of_code/_cog.py
+++ b/bot/exts/advent_of_code/_cog.py
@@ -58,7 +58,7 @@ class AdventOfCode(commands.Cog):
 
         self.scheduler = scheduling.Scheduler(self.__class__.__name__)
 
-    def cog_unload(self) -> None:
+    async def cog_unload(self) -> None:
         """Cancel all tasks on cog unload."""
         self.scheduler.cancel_all()
 

--- a/bot/exts/advent_of_code/_cog.py
+++ b/bot/exts/advent_of_code/_cog.py
@@ -138,7 +138,7 @@ class AdventOfCode(commands.Cog):
         if not ctx.invoked_subcommand:
             await self.bot.invoke_help_command(ctx)
 
-    @with_role(Roles.admins, fail_silently=True)
+    @with_role(Roles.admins, Roles.events_lead, fail_silently=True)
     @adventofcode_group.command(
         name="completionist_toggle",
         aliases=("ct", "toggle"),

--- a/bot/exts/advent_of_code/_helpers.py
+++ b/bot/exts/advent_of_code/_helpers.py
@@ -70,33 +70,6 @@ class FetchingLeaderboardFailedError(Exception):
     """Raised when one or more leaderboards could not be fetched at all."""
 
 
-def _format_leaderboard_line(rank: int, data: dict[str, Any], *, is_author: bool) -> str:
-    """
-    Build a string representing a line of the leaderboard.
-
-    Parameters:
-        rank:
-            Rank in the leaderboard of this entry.
-
-        data:
-            Mapping with entry information.
-
-    Keyword arguments:
-        is_author:
-            Whether to address the name displayed in the returned line
-            personally.
-
-    Returns:
-        A formatted line for the leaderboard.
-    """
-    return AOC_TABLE_TEMPLATE.format(
-        rank=rank,
-        name=data["name"] if not is_author else f"(You) {data['name']}",
-        score=str(data["score"]),
-        stars=f"({data['star_1']}, {data['star_2']})"
-    )
-
-
 def leaderboard_sorting_function(entry: tuple[str, dict]) -> tuple[int, int]:
     """
     Provide a sorting value for our leaderboard.

--- a/bot/exts/core/error_handler.py
+++ b/bot/exts/core/error_handler.py
@@ -44,7 +44,7 @@ class ErrorHandler(Cog):
         In the future, I would expect this to be used as a place
             to push errors to a sentry instance.
         """
-        log.trace(f"Handling a raised error {error} from {ctx.command}")
+        log.trace("Handling a %s raised from %s", type(error), ctx.command)
 
         if isinstance(error, errors.UserInputError):
             await self.handle_user_input_error(ctx, error)

--- a/bot/log.py
+++ b/bot/log.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 import sentry_sdk
-from pydis_core.utils.logging import get_logger
+from pydis_core.utils.logging import TRACE_LEVEL, get_logger
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 from bot.constants import Bot, GIT_SHA
@@ -11,10 +11,9 @@ from bot.constants import Bot, GIT_SHA
 def setup_logging() -> None:
     """Configure logging for the bot."""
     root_log = get_logger()
-    root_log.setLevel(logging.DEBUG if Bot.debug else logging.INFO)
+    root_log.setLevel(TRACE_LEVEL if Bot.trace_logging else logging.DEBUG if Bot.debug else logging.INFO)
 
     ch = logging.StreamHandler(stream=sys.stdout)
-    ch.setLevel(logging.DEBUG)
     format_string = logging.Formatter("%(asctime)s | %(name)s | %(levelname)s | %(message)s")
     ch.setFormatter(format_string)
     root_log.addHandler(ch)

--- a/bot/log.py
+++ b/bot/log.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 import sentry_sdk
-from pydis_core.utils.logging import TRACE_LEVEL, get_logger
+from pydis_core.utils.logging import TRACE_LEVEL, get_logger, log_format
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 from bot.constants import Bot, GIT_SHA
@@ -14,14 +14,8 @@ def setup_logging() -> None:
     root_log.setLevel(TRACE_LEVEL if Bot.trace_logging else logging.DEBUG if Bot.debug else logging.INFO)
 
     ch = logging.StreamHandler(stream=sys.stdout)
-    format_string = logging.Formatter("%(asctime)s | %(name)s | %(levelname)s | %(message)s")
-    ch.setFormatter(format_string)
+    ch.setFormatter(log_format)
     root_log.addHandler(ch)
-
-    get_logger("discord").setLevel(logging.WARNING)
-
-    # Set back to the default of INFO even if asyncio's debug mode is enabled.
-    get_logger("asyncio").setLevel(logging.INFO)
 
     root_log.info("Logging initialization complete.")
 

--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -131,8 +131,14 @@ def in_month(*allowed_months: Month) -> Callable:
 def with_role(*role_ids: int, fail_silently: bool = False) -> Callable:
     """Check to see whether the invoking user has any of the roles specified in role_ids."""
     async def predicate(ctx: Context) -> bool:
+        log.debug(
+            "Checking if %s has one of the following role IDs %s. Fail silently is set to %s.",
+            ctx.author,
+            role_ids,
+            fail_silently
+        )
         try:
-            await commands.has_any_role(*role_ids).predicate(ctx)
+            return await commands.has_any_role(*role_ids).predicate(ctx)
         except commands.MissingAnyRole as e:
             if fail_silently:
                 raise SilentRoleFailure from e


### PR DESCRIPTION
Labeled as **DO NOT MERGE** as I will need to migrate redis caches to the new namespaces before merging this.

This adds a new command, and redis cache, to control whether the AoC completionist role is issued.

This also refactors the cog a little it while I was there. As usual, this PR is best reviewed commit-by-commit.