### PR TITLE
Pass exception value into Sentry

### DIFF
--- a/bot/exts/core/error_handler.py
+++ b/bot/exts/core/error_handler.py
@@ -58,7 +58,10 @@ class ErrorHandler(Cog):
             embed = self._get_error_embed("Command not found", str(error))
         else:
             # If we haven't handled it by this point, it is considered an unexpected/handled error.
-            log.exception(f"Error executing command invoked by {ctx.message.author}: {ctx.message.content}")
+            log.exception(
+                f"Error executing command invoked by {ctx.message.author}: {ctx.message.content}",
+                exc_info=error,
+            )
             embed = self._get_error_embed(
                 "Unexpected error",
                 "Sorry, an unexpected error occurred. Please let us know!\n\n"


### PR DESCRIPTION
Sentry could use the extra information, see for instance [1], we may not need to unwrap this into `error.__cause__` since Python on its own should already expand that.

[1]: https://python-discord.sentry.io/issues/5126046667/?project=4506666249945088&query=&referrer=issue-stream&statsPeriod=90d&stream_index=5,