### PR TITLE
Add codejam support command group.

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -181,6 +181,7 @@ class _Roles(EnvConfig, env_prefix="ROLE_"):
     event_runner: int = 940911658799333408
     summer_aoc: int = 988801794668908655
     code_jam_participants: int = 991678713093705781
+    code_jam_support: int = 1254657197535920141
     helpers: int = 267630620367257601
     aoc_completionist: int = 1191547731873894440
     bots: int = 277546923144249364


### PR DESCRIPTION
Adds a command group called `support` to the code jam cog to enabling toggling of the Code Jam Support role for admins and event team members.

Closes #126 