### PR TITLE
&aoc join -> /aoc join in the error message

### DIFF
--- a/bot/exts/advent_of_code/_helpers.py
+++ b/bot/exts/advent_of_code/_helpers.py
@@ -188,7 +188,7 @@ def _format_leaderboard(leaderboard: dict[str, dict], self_placement_name: str |
         raise commands.BadArgument(
             "Sorry, your profile does not exist in this leaderboard."
             "\n\n"
-            f"To join our leaderboard, run the command `{Bot.prefix}aoc join`."
+            f"To join our leaderboard, run the command `/aoc join`."
             " If you've joined recently, please wait up to 30 minutes for our leaderboard to refresh."
         )
     return "\n".join(leaderboard_lines)

--- a/bot/exts/advent_of_code/_helpers.py
+++ b/bot/exts/advent_of_code/_helpers.py
@@ -14,7 +14,7 @@ from pydis_core.utils import logging, paste_service
 
 import bot
 from bot.bot import SirRobin
-from bot.constants import AdventOfCode, Bot, Channels, Colours, Roles
+from bot.constants import AdventOfCode, Channels, Colours, Roles
 from bot.exts.advent_of_code import _caches
 
 log = logging.get_logger(__name__)
@@ -188,7 +188,7 @@ def _format_leaderboard(leaderboard: dict[str, dict], self_placement_name: str |
         raise commands.BadArgument(
             "Sorry, your profile does not exist in this leaderboard."
             "\n\n"
-            f"To join our leaderboard, run the command `/aoc join`."
+            "To join our leaderboard, run the command `/aoc join`."
             " If you've joined recently, please wait up to 30 minutes for our leaderboard to refresh."
         )
     return "\n".join(leaderboard_lines)


### PR DESCRIPTION
The join command is actually a slash command, but the bot tells people to do `&aoc join`, and it ends up just not working. I've seen lots of people run into this; [most recent example](https://discord.com/channels/267624335836053506/897932607545823342/1318514905195745281).

I've never worked on Discord bots so I'm not sure if this is the correct way to show slash commands (like the way it was `{Bot.prefix}` instead of just a literal ampersand), but either way it needs correction.