### PR TITLE
Code jam role removal

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -181,6 +181,7 @@ class _Roles(EnvConfig, env_prefix="ROLE_"):
     event_runner: int = 940911658799333408
     summer_aoc: int = 988801794668908655
     code_jam_participants: int = 991678713093705781
+    code_jam_team_leads: int = 1262472493755797594
     code_jam_support: int = 1254657197535920141
     helpers: int = 267630620367257601
     aoc_completionist: int = 1191547731873894440

--- a/bot/constants.py
+++ b/bot/constants.py
@@ -187,10 +187,6 @@ class _Roles(EnvConfig, env_prefix="ROLE_"):
     bots: int = 277546923144249364
     moderation_team: int = 267629731250176001
 
-    team_list: int = 1222691191582097418
-    team_dict: int = 1222691368653033652
-    team_tuple: int = 1222691399246286888
-
 
 Roles = _Roles()
 

--- a/bot/exts/code_jams/_cog.py
+++ b/bot/exts/code_jams/_cog.py
@@ -96,7 +96,7 @@ class CodeJams(commands.Cog):
     @commands.has_any_role(Roles.admins, Roles.events_lead)
     async def end(self, ctx: commands.Context) -> None:
         """
-        Delete all code jam channels.
+        Delete all code jam channels and team-specific roles.
 
         A confirmation message is displayed with the categories and channels
         that are going to be deleted, by pressing "Confirm" the deletion
@@ -142,6 +142,13 @@ class CodeJams(commands.Cog):
             view=confirm_view
         )
         await confirm_view.wait()
+
+        # Unassign the code jam participant and team lead roles, without deleting the roles themselves
+        for permanent_role_id in (Roles.code_jam_team_leads, Roles.code_jam_participants):
+            permanent_role = await ctx.guild.get_role(permanent_role_id)
+            for user in permanent_role.members:
+                await user.remove_roles(permanent_role)
+
         await ctx.send("Code Jam has officially ended! :sunrise:")
 
     @codejam.command()


### PR DESCRIPTION
This just adds to `&codejam end` the int eval that I used to unassign the code jam participant and code jam team lead roles. 