### PR TITLE
Limit the length of the donated hardware name

### DIFF
--- a/bot/exts/smart_eval/_cog.py
+++ b/bot/exts/smart_eval/_cog.py
@@ -57,6 +57,9 @@ class SmartEval(commands.Cog):
         hardware_name = hardware_name.replace("*", "")
         hardware_name = hardware_name.replace("_", " ")
 
+        if len(hardware_name) > 800:
+            return "Goose Processing Unit 69000"
+
         return hardware_name
 
     @commands.command()


### PR DESCRIPTION
Message example: https://discord.com/channels/267624335836053506/1356544424619806781/1356631764998553652

The `improve_gpu_name` function can increase the length of a string, creating a GPU name that will cause the `ctx.reply` call to fail.