### PR TITLE
Allow certain roles to run AoC commands in November

### DIFF
--- a/bot/constants.py
+++ b/bot/constants.py
@@ -178,6 +178,7 @@ class _Roles(EnvConfig, env_prefix="ROLE_"):
     admins: int = 267628507062992896
     advent_of_code: int = 518565788744024082
     code_jam_event_team: int = 787816728474288181
+    core_devs: int = 587606783669829632
     events_lead: int = 778361735739998228
     event_runner: int = 940911658799333408
     summer_aoc: int = 988801794668908655

--- a/bot/exts/advent_of_code/_cog.py
+++ b/bot/exts/advent_of_code/_cog.py
@@ -36,6 +36,8 @@ AOC_WHITELIST = AOC_WHITELIST_RESTRICTED + (Channels.advent_of_code,)
 
 AOC_REDIRECT = (Channels.advent_of_code_commands, Channels.sir_lancebot_playground, Channels.bot_commands)
 
+EARLY_ACCESS_ROLES = (Roles.admins, Roles.events_lead, Roles.core_devs)
+
 
 class AdventOfCode(commands.Cog):
     """Advent of Code festivities! Ho Ho Ho!"""
@@ -326,6 +328,7 @@ class AdventOfCode(commands.Cog):
             await ctx.reply("You don't have an Advent of Code account linked.")
 
     @in_month(Month.DECEMBER, Month.JANUARY, Month.FEBRUARY)
+    @in_month(Month.NOVEMBER, roles=EARLY_ACCESS_ROLES)
     @adventofcode_group.command(
         name="dayandstar",
         aliases=("daynstar", "daystar"),
@@ -364,6 +367,7 @@ class AdventOfCode(commands.Cog):
         await message.edit(view=None)
 
     @in_month(Month.DECEMBER, Month.JANUARY, Month.FEBRUARY)
+    @in_month(Month.NOVEMBER, roles=EARLY_ACCESS_ROLES)
     @adventofcode_group.command(
         name="leaderboard",
         aliases=("board", "lb"),
@@ -445,6 +449,7 @@ class AdventOfCode(commands.Cog):
         await ctx.send(embed=self.cached_no_global)
 
     @in_month(Month.DECEMBER, Month.JANUARY, Month.FEBRUARY)
+    @in_month(Month.NOVEMBER, roles=EARLY_ACCESS_ROLES)
     @adventofcode_group.command(
         name="stats",
         aliases=("dailystats", "ds"),

--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -152,7 +152,7 @@ def in_month(*allowed_months: Month, roles: tuple[int, ...] = ()) -> Callable:
 
         # D.py will assign this attribute when `callable_` is registered as a listener
         elif hasattr(callable_, "__cog_listener__"):
-            if roles is not None:
+            if roles:
                 raise ValueError("Role restrictions are not available for listeners.")
             log.debug(f"Listener {callable_.__qualname__} will be locked to {human_months(allowed_months)}")
             actual_deco = in_month_listener(*allowed_months)

--- a/bot/utils/decorators.py
+++ b/bot/utils/decorators.py
@@ -3,7 +3,7 @@ import functools
 from collections.abc import Callable, Container
 
 from discord.ext import commands
-from discord.ext.commands import Command, Context
+from discord.ext.commands import CheckFailure, Command, Context
 from pydis_core.utils import logging
 
 from bot.constants import Channels, Month
@@ -69,28 +69,64 @@ def in_month_listener(*allowed_months: Month) -> Callable:
     return decorator
 
 
-def in_month_command(*allowed_months: Month) -> Callable:
+def in_month_command(*allowed_months: Month, roles: tuple[int, ...] = ()) -> Callable:
     """
-    Check whether the command was invoked in one of `enabled_months`.
+    Check whether the command was invoked in one of `allowed_months`.
+
+    The check can be limited to certain roles.
+    To enable the supplied months for everyone, don't set a value for `roles`.
+
+    If a command is decorated several times with this, it only needs to pass one of the checks.
 
     Uses the current UTC month at the time of running the predicate.
     """
     async def predicate(ctx: Context) -> bool:
-        current_month = resolve_current_month()
-        can_run = current_month in allowed_months
-
-        log.debug(
-            f"Command '{ctx.command}' is locked to months {human_months(allowed_months)}. "
-            f"Invoking it in month {current_month!s} is {'allowed' if can_run else 'disallowed'}."
-        )
-        if can_run:
+        command = ctx.command
+        if "month_checks" not in command.extras:
+            log.debug(f"No month checks found for command {command}.")
             return True
-        raise InMonthCheckFailure(f"Command can only be used in {human_months(allowed_months)}")
 
-    return commands.check(predicate)
+        everyone_error = None
+        privileged_user = False
+        allowed_months_for_user = set()
+        current_month = resolve_current_month()
+        for checked_roles, checked_months in command.extras["month_checks"].items():
+            if checked_roles:
+                uroles = ctx.author.roles
+                if not uroles or not (set(checked_roles) & set(r.id for r in uroles)):
+                    log.debug(f"Month check for roles {checked_roles} doesn't apply to {ctx.author}.")
+                    continue
+
+            if current_month in checked_months:
+                log.debug(f"Month check for roles {checked_roles} passed for {ctx.author}.")
+                return True
+
+            log.debug(f"Month check for roles {checked_roles} didn't pass for {ctx.author}.")
+            if not checked_roles:
+                everyone_error = InMonthCheckFailure(f"Command can only be used in {human_months(checked_months)}")
+            else:
+                privileged_user = True
+            allowed_months_for_user |= set(checked_months)
+
+        if privileged_user:
+            allowed_months_for_user = sorted(allowed_months_for_user)
+            raise InMonthCheckFailure(f"You can run this command only in {human_months(allowed_months_for_user)}")
+        if everyone_error:
+            raise everyone_error
+        raise CheckFailure("You cannot run this command.")
+
+    def decorator(func: Command) -> Command:
+        if "month_checks" in func.extras:
+            func.extras["month_checks"][roles] = allowed_months
+            return func
+
+        func.extras["month_checks"] = {roles: allowed_months}
+        return commands.check(predicate)(func)
+
+    return decorator
 
 
-def in_month(*allowed_months: Month) -> Callable:
+def in_month(*allowed_months: Month, roles: tuple[int, ...] = ()) -> Callable:
     """
     Universal decorator for season-locking commands and listeners alike.
 
@@ -112,10 +148,12 @@ def in_month(*allowed_months: Month) -> Callable:
         # Functions decorated as commands are turned into instances of `Command`
         if isinstance(callable_, Command):
             log.debug(f"Command {callable_.qualified_name} will be locked to {human_months(allowed_months)}")
-            actual_deco = in_month_command(*allowed_months)
+            actual_deco = in_month_command(*allowed_months, roles=roles)
 
         # D.py will assign this attribute when `callable_` is registered as a listener
         elif hasattr(callable_, "__cog_listener__"):
+            if roles is not None:
+                raise ValueError("Role restrictions are not available for listeners.")
             log.debug(f"Listener {callable_.__qualname__} will be locked to {human_months(allowed_months)}")
             actual_deco = in_month_listener(*allowed_months)
 


### PR DESCRIPTION
![Untitled](https://github.com/user-attachments/assets/87d282e3-a8fb-4159-bb10-a1879d9c51e5)

The goal is give staff time to make sure that commands work properly in production without having to wait until December. I restricted it to a few roles because it's just for sanity check.